### PR TITLE
Updated About page

### DIFF
--- a/project/lib/templates/lib/about.html
+++ b/project/lib/templates/lib/about.html
@@ -95,7 +95,7 @@
         developed the computer vision backend.
         For full release notes refer to <a href="{% url 'release' %}">CoralNet Beta release-notes</a>.
     </p>
-    <h4>CoralNet Gamma (Work in Progress!)</h4>
+    <h4>CoralNet Beta 2 (Work in Progress!)</h4>
     <p>
         In early 2019
         <a href="https://www.frontiersin.org/articles/10.3389/fmars.2019.00222/full">Williams et al.</a> at NOAA
@@ -104,7 +104,7 @@
         This study thus suggests that CoralNet was finally accurate enough to address the manual annotation bottleneck!
     </p>
     <p>
-        Following these results a second grant was received from NOAA to develop CoralNet Gamma.
+        Following these results a second grant was received from NOAA to develop CoralNet Beta 2.
         This work will proceed along two main avenues.
         First, an API will be developed to allow the deployment of a trained classifier on vast number of images.
         This, in turn, enables the creation of a repository of trained classifiers from which users can choose from.


### PR DESCRIPTION
I took some time today to update the about page. The main change is a "story" section that tells the story of CoralNet and the different releases.

I also added a reference to Ivor's paper, and updated the People list.

@StephenChan @qiminchen : let me know if you want a hyper-link next to your names.
