### PR TITLE
Changed spacer exporter to iterate over annotations rather than points.

### DIFF
--- a/project/config/settings/dev_beijbom.py
+++ b/project/config/settings/dev_beijbom.py
@@ -2,5 +2,5 @@ from .base_devserver import *
 
 # Pick one.
 # from .storage_s3 import *
-# from .storage_local import *
+from .storage_local import *
 from .storage_s3_regtests import *


### PR DESCRIPTION
Export stopped again due to this bug: https://github.com/beijbom/coralnet/issues/225.

This PR changes so we iterate over annotations rather than points. I also think this i a bit faster since the table JOIN happens on the DB level.