### PR TITLE
More meta-data to labelset export

### DIFF
--- a/project/vision_backend/management/commands/vb_export_spacer_data.py
+++ b/project/vision_backend/management/commands/vb_export_spacer_data.py
@@ -29,7 +29,13 @@ class Command(BaseCommand):
     def labelset_json(self):
         cont = []
         for label in Label.objects.filter():
-            cont.append([label.pk, label.name, label.default_code, label.group.name])
+            cont.append({'id': label.pk,
+                         'name': label.name,
+                         'code': label.default_code,
+                         'group': label.group.name,
+                         'duplicate_of': str(label.duplicate),
+                         'is_verified': label.verified,
+                         'ann_count': label.ann_count})
         return json.dumps(cont, indent=2)
 
     @staticmethod


### PR DESCRIPTION
The export to S3 is complete, believe it or not. We just need to add the dups information to the labelset export meta-data and re-run that export. This PR does the required changes. @qiminchen : note that I changed from a list to a dict since we added more stuff.