### PR TITLE
Better consistency of train-images and points-per-image thresholds

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -123,7 +123,7 @@ SECRET_KEY=
 # Recommended when running unit tests or when just trying out classifiers in
 # dev environments. This lowers the image count requirement for training, thus
 # greatly speeding up any tests involving setting up training data.
-#MIN_NBR_ANNOTATED_IMAGES=2
+#TRAINING_MIN_IMAGES=2
 
 # Recommended when trying out the front page map. Again, the regular image
 # count requirements to get markers to appear on the map (or appear with higher

--- a/.env.dist
+++ b/.env.dist
@@ -120,11 +120,10 @@ SECRET_KEY=
 # make it 'dev_' followed by your name.
 #SPACER_JOB_HASH=your_hash_here
 
-# Recommended when trying out classifiers in dev environments. It can be a bit
-# onerous to meet the regular image count requirement for testing purposes,
-# in which case you can lower the requirement here.
-# But don't make it lower than spacer's own requirement, which is 10.
-#MIN_NBR_ANNOTATED_IMAGES=10
+# Recommended when running unit tests or when just trying out classifiers in
+# dev environments. This lowers the image count requirement for training, thus
+# greatly speeding up any tests involving setting up training data.
+#MIN_NBR_ANNOTATED_IMAGES=2
 
 # Recommended when trying out the front page map. Again, the regular image
 # count requirements to get markers to appear on the map (or appear with higher

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -23,7 +23,7 @@ jobs:
       CORALNET_DATABASE_HOST: localhost
       CORALNET_SECRET_KEY: ci-secret-key
       # This is for speeding up tests.
-      CORALNET_MIN_NBR_ANNOTATED_IMAGES: 2
+      CORALNET_TRAINING_MIN_IMAGES: 2
 
     services:
       postgres:

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -22,6 +22,8 @@ jobs:
       # this must be explicitly specified for CI for some reason.
       CORALNET_DATABASE_HOST: localhost
       CORALNET_SECRET_KEY: ci-secret-key
+      # This is for speeding up tests.
+      CORALNET_MIN_NBR_ANNOTATED_IMAGES: 2
 
     services:
       postgres:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ For info about the semantic versioning used here, see `docs/versions.rst`.
 
 ## 1.7 (WIP)
 
-- The new `EXTRACTORS_BUCKET` setting is now required in .env when using a non-dummy feature extractor.
+- The new `EXTRACTORS_BUCKET` setting is now required when using a non-dummy feature extractor.
+- The `MIN_NBR_ANNOTATED_IMAGES` setting has been renamed to `TRAINING_MIN_IMAGES`. Also, it's now tied to the corresponding pyspacer setting, which means that lowering this number will speed up unit tests.
 - Updates to required packages:
   - pyspacer 0.4.1 -> 0.6.1
   - Pillow 9.4.0 -> 10.1.0

--- a/project/config/settings.py
+++ b/project/config/settings.py
@@ -290,7 +290,6 @@ NEW_CLASSIFIER_TRAIN_TH = 1.1
 NEW_CLASSIFIER_IMPROVEMENT_TH = 1.01
 
 # This many images must be annotated before a first classifier is trained.
-# TODO: Configure this on spacer's side as well
 MIN_NBR_ANNOTATED_IMAGES = env.int('MIN_NBR_ANNOTATED_IMAGES', default=20)
 
 # Naming schemes
@@ -327,6 +326,8 @@ SPACER = {
 
     'MAX_IMAGE_PIXELS': (
         IMAGE_UPLOAD_MAX_DIMENSIONS[0] * IMAGE_UPLOAD_MAX_DIMENSIONS[1]),
+
+    'MIN_TRAINIMAGES': MIN_NBR_ANNOTATED_IMAGES,
 }
 
 # If True, feature extraction just returns dummy results to speed up testing.

--- a/project/config/settings.py
+++ b/project/config/settings.py
@@ -246,6 +246,8 @@ DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 # Upload/data restrictions
 #
 
+MAX_POINTS_PER_IMAGE = 1000
+
 # The maximum size (in bytes) that an upload will be before it
 # gets streamed to the file system.
 #
@@ -326,6 +328,7 @@ SPACER = {
 
     'MAX_IMAGE_PIXELS': (
         IMAGE_UPLOAD_MAX_DIMENSIONS[0] * IMAGE_UPLOAD_MAX_DIMENSIONS[1]),
+    'MAX_POINTS_PER_IMAGE': MAX_POINTS_PER_IMAGE,
 
     'MIN_TRAINIMAGES': MIN_NBR_ANNOTATED_IMAGES,
 }

--- a/project/config/settings.py
+++ b/project/config/settings.py
@@ -292,7 +292,7 @@ NEW_CLASSIFIER_TRAIN_TH = 1.1
 NEW_CLASSIFIER_IMPROVEMENT_TH = 1.01
 
 # This many images must be annotated before a first classifier is trained.
-MIN_NBR_ANNOTATED_IMAGES = env.int('MIN_NBR_ANNOTATED_IMAGES', default=20)
+TRAINING_MIN_IMAGES = env.int('TRAINING_MIN_IMAGES', default=20)
 
 # Naming schemes
 FEATURE_VECTOR_FILE_PATTERN = '{full_image_path}.featurevector'
@@ -330,7 +330,7 @@ SPACER = {
         IMAGE_UPLOAD_MAX_DIMENSIONS[0] * IMAGE_UPLOAD_MAX_DIMENSIONS[1]),
     'MAX_POINTS_PER_IMAGE': MAX_POINTS_PER_IMAGE,
 
-    'MIN_TRAINIMAGES': MIN_NBR_ANNOTATED_IMAGES,
+    'MIN_TRAINIMAGES': TRAINING_MIN_IMAGES,
 }
 
 # If True, feature extraction just returns dummy results to speed up testing.

--- a/project/cpce/tests/test_upload_general_cases.py
+++ b/project/cpce/tests/test_upload_general_cases.py
@@ -5,6 +5,7 @@ import codecs
 from unittest import mock
 
 from django.core.files.base import ContentFile
+from django.test.utils import override_settings
 from django.urls import reverse
 
 from images.models import Point
@@ -521,6 +522,24 @@ class ContentsEdgeAndErrorCasesTest(ClientTest, UploadAnnotationsCpcTestMixin):
                 (20, 20, 2, self.img1.pk),
                 (150, 90, 3, self.img1.pk),
             })
+
+    @override_settings(MAX_POINTS_PER_IMAGE=3)
+    def test_max_points(self):
+        self.do_success(
+            [(10*15, 10*15), (20*15, 20*15), (30*15, 30*15)],
+            {
+                (10, 10, 1, self.img1.pk),
+                (20, 20, 2, self.img1.pk),
+                (30, 30, 3, self.img1.pk),
+            })
+
+    @override_settings(MAX_POINTS_PER_IMAGE=3)
+    def test_above_max_points(self):
+        self.do_error(
+            [(10*15, 10*15), (20*15, 20*15), (30*15, 30*15), (40*15, 40*15)],
+            "From file 1.cpc:"
+            " Found 4 points, which exceeds the"
+            " maximum allowed of 3")
 
     def test_label_not_in_labelset(self):
         self.do_error(

--- a/project/images/forms.py
+++ b/project/images/forms.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.forms import Form, ModelForm, BaseModelFormSet
@@ -367,8 +368,6 @@ class PointGenForm(Form):
             "js/PointGenFormHelper.js",
         )
 
-    MAX_NUM_POINTS = 1000
-
     point_generation_type = ChoiceField(
         label='Point generation type',
         choices=Source.POINT_GENERATION_CHOICES,
@@ -385,26 +384,26 @@ class PointGenForm(Form):
     # For simple random
     simple_number_of_points = IntegerField(
         label='Number of annotation points', required=False,
-        min_value=1, max_value=MAX_NUM_POINTS,
+        min_value=1, max_value=settings.MAX_POINTS_PER_IMAGE,
         widget=NumberInput(attrs={'size': 3}),
     )
 
     # For stratified random and uniform grid
     number_of_cell_rows = IntegerField(
         label='Number of cell rows', required=False,
-        min_value=1, max_value=MAX_NUM_POINTS,
+        min_value=1, max_value=settings.MAX_POINTS_PER_IMAGE,
         widget=NumberInput(attrs={'size': 3}),
     )
     number_of_cell_columns = IntegerField(
         label='Number of cell columns', required=False,
-        min_value=1, max_value=MAX_NUM_POINTS,
+        min_value=1, max_value=settings.MAX_POINTS_PER_IMAGE,
         widget=NumberInput(attrs={'size': 3}),
     )
 
     # For stratified random
     stratified_points_per_cell = IntegerField(
         label='Points per cell', required=False,
-        min_value=1, max_value=MAX_NUM_POINTS,
+        min_value=1, max_value=settings.MAX_POINTS_PER_IMAGE,
         widget=NumberInput(attrs={'size': 3}),
     )
 
@@ -471,7 +470,7 @@ class PointGenForm(Form):
         if not self._errors:
             # No errors so far, so do a final check of
             # the total number of points specified.
-            # It should be between 1 and MAX_NUM_POINTS.
+            # It should be between 1 and settings.MAX_POINTS_PER_IMAGE.
             num_points = 0
 
             if point_gen_type == PointGen.Types.SIMPLE:
@@ -486,11 +485,11 @@ class PointGenForm(Form):
                     cleaned_data['number_of_cell_rows']
                     * cleaned_data['number_of_cell_columns'])
 
-            if num_points > PointGenForm.MAX_NUM_POINTS:
+            if num_points > settings.MAX_POINTS_PER_IMAGE:
                 # Raise a non-field error (error applying to the form as a
                 # whole).
                 raise ValidationError(
                     "You specified {num_points} points total."
                     " Please make it no more than {max_points}.".format(
                         num_points=num_points,
-                        max_points=PointGenForm.MAX_NUM_POINTS))
+                        max_points=settings.MAX_POINTS_PER_IMAGE))

--- a/project/images/models.py
+++ b/project/images/models.py
@@ -414,7 +414,7 @@ class Source(models.Model):
             self.image_set.confirmed().with_features().count()
         )
         if (nbr_confirmed_images_with_features
-                < settings.MIN_NBR_ANNOTATED_IMAGES):
+                < settings.TRAINING_MIN_IMAGES):
             return False, "Not enough annotated images for initial training"
 
         try:

--- a/project/images/tests/test_source_other.py
+++ b/project/images/tests/test_source_other.py
@@ -549,7 +549,7 @@ class SourceMainTest(ClientTest):
                         "Following the browse link should show only image"
                         " results of the specified status"))
 
-    @override_settings(MIN_NBR_ANNOTATED_IMAGES=3)
+    @override_settings(TRAINING_MIN_IMAGES=3)
     def test_automated_annotation_section(self):
         source = self.create_source(self.user)
 

--- a/project/images/utils.py
+++ b/project/images/utils.py
@@ -403,7 +403,7 @@ def source_robot_status(source_id):
     if source.has_robot():
         status['nbr_images_until_next_robot'] = status['nbr_in_current_model'] * settings.NEW_CLASSIFIER_TRAIN_TH - status['nbr_human_annotated_images']
     else:
-        status['nbr_images_until_next_robot'] = settings.MIN_NBR_ANNOTATED_IMAGES - status['nbr_human_annotated_images']
+        status['nbr_images_until_next_robot'] = settings.TRAINING_MIN_IMAGES - status['nbr_human_annotated_images']
     status['nbr_images_until_next_robot'] = int(math.ceil(status['nbr_images_until_next_robot']))
 
     status['need_robot'], _ = source.need_new_robot()

--- a/project/images/views.py
+++ b/project/images/views.py
@@ -236,7 +236,7 @@ def source_main(request, source_id):
         'latest_images': latest_images,
         'image_stats': image_stats,
         'robot_stats': robot_stats,
-        'min_nbr_annotated_images': settings.MIN_NBR_ANNOTATED_IMAGES,
+        'min_nbr_annotated_images': settings.TRAINING_MIN_IMAGES,
         'news_items': [item.render_view() for item in
                        NewsItem.objects.filter(source_id=source.id).order_by('-pk')]
     })

--- a/project/upload/tests/test_annotations_general_cases.py
+++ b/project/upload/tests/test_annotations_general_cases.py
@@ -6,6 +6,7 @@ import codecs
 from unittest import mock
 
 from django.core.files.base import ContentFile
+from django.test.utils import override_settings
 from django.urls import reverse
 
 from images.models import Point
@@ -461,6 +462,24 @@ class UploadAnnotationsContentsTest(ClientTest, UploadAnnotationsCsvTestMixin):
                 (20, 20, 2, self.img1.pk),
                 (150, 90, 3, self.img1.pk),
             })
+
+    @override_settings(MAX_POINTS_PER_IMAGE=3)
+    def test_max_points(self):
+        self.do_success(
+            [(10, 10), (20, 20), (30, 30)],
+            {
+                (10, 10, 1, self.img1.pk),
+                (20, 20, 2, self.img1.pk),
+                (30, 30, 3, self.img1.pk),
+            })
+
+    @override_settings(MAX_POINTS_PER_IMAGE=3)
+    def test_above_max_points(self):
+        self.do_error(
+            [(10, 10), (20, 20), (30, 30), (40, 40)],
+            "For image 1.png:"
+            " Found 4 points, which exceeds the"
+            " maximum allowed of 3")
 
     def test_label_not_in_labelset(self):
         self.do_error(

--- a/project/upload/utils.py
+++ b/project/upload/utils.py
@@ -6,6 +6,7 @@ from typing import Callable, Dict, List, Optional, Tuple
 
 import chardet
 import charset_normalizer
+from django.conf import settings
 from django.urls import reverse
 
 from annotations.models import ImageAnnotationInfo
@@ -325,6 +326,13 @@ def annotations_csv_verify_contents(csv_annotations, source):
             # planning to upload later, or an image they're not planning
             # to upload but are still tracking in their records.
             continue
+
+        point_count = len(annotations_for_image)
+        if point_count > settings.MAX_POINTS_PER_IMAGE:
+            raise FileProcessError(
+                f"For image {image_name}:"
+                f" Found {point_count} points, which exceeds the"
+                f" maximum allowed of {settings.MAX_POINTS_PER_IMAGE}")
 
         for point_number, point_dict in enumerate(annotations_for_image, 1):
 

--- a/project/vision_backend/tests/tasks/test_classify.py
+++ b/project/vision_backend/tests/tasks/test_classify.py
@@ -4,7 +4,6 @@ from unittest import mock
 from django.core.cache import cache
 from django.test import override_settings
 import numpy as np
-import spacer.config as spacer_config
 
 from accounts.utils import get_robot_user, is_robot_user
 from annotations.models import Annotation
@@ -545,8 +544,7 @@ class ClassifyImageTest(
         The image to be classified has two points with the same row/column.
         """
         # Provide enough data for training
-        self.upload_images_for_training(
-            train_image_count=spacer_config.MIN_TRAINIMAGES, val_image_count=1)
+        self.upload_images_for_training()
         # Add one image without annotations, including a duplicate point
         img = self.upload_image_with_dupe_points('has_dupe.png')
         # Extract features

--- a/project/vision_backend/tests/tasks/test_extract_features.py
+++ b/project/vision_backend/tests/tasks/test_extract_features.py
@@ -3,7 +3,6 @@ from unittest import mock
 from django.conf import settings
 from django.core.files.storage import get_storage_class
 from django.test import override_settings
-import spacer.config as spacer_config
 from spacer.data_classes import ImageFeatures
 from spacer.exceptions import SpacerInputError
 
@@ -153,9 +152,7 @@ class AbortCasesTest(BaseTaskTest, ErrorReportTestMixin, JobUtilsMixin):
         progress.
         """
         # Provide enough data for training. Extract features.
-        self.upload_images_for_training(
-            train_image_count=spacer_config.MIN_TRAINIMAGES,
-            val_image_count=1)
+        self.upload_images_for_training()
         run_scheduled_jobs_until_empty()
         queue_and_run_collect_spacer_jobs()
 

--- a/project/vision_backend/tests/tasks/test_train.py
+++ b/project/vision_backend/tests/tasks/test_train.py
@@ -123,7 +123,7 @@ class TrainClassifierTest(BaseTaskTest, JobUtilsMixin):
         clf_1 = self.source.get_current_classifier()
 
         # Upload enough additional images for the next training to happen.
-        old_image_count = settings.MIN_NBR_ANNOTATED_IMAGES + 1
+        old_image_count = settings.TRAINING_MIN_IMAGES + 1
         new_image_count = math.ceil(
             old_image_count*settings.NEW_CLASSIFIER_TRAIN_TH)
         added_image_count = new_image_count - old_image_count
@@ -165,7 +165,7 @@ class TrainClassifierTest(BaseTaskTest, JobUtilsMixin):
             'train.png', with_labels=True)
         # Other annotated images to get enough for training
         self.upload_images_for_training(
-            train_image_count=settings.MIN_NBR_ANNOTATED_IMAGES-1,
+            train_image_count=settings.TRAINING_MIN_IMAGES-1,
             val_image_count=0)
 
         # Extract features
@@ -264,7 +264,7 @@ class AbortCasesTest(BaseTaskTest, ErrorReportTestMixin, JobUtilsMixin):
         # But set CoralNet's requirement 1 higher than that image count.
         min_images = self.source.image_set.count() + 1
 
-        with override_settings(MIN_NBR_ANNOTATED_IMAGES=min_images):
+        with override_settings(TRAINING_MIN_IMAGES=min_images):
             # Check source
             run_scheduled_jobs_until_empty()
 
@@ -307,7 +307,7 @@ class AbortCasesTest(BaseTaskTest, ErrorReportTestMixin, JobUtilsMixin):
         # The intersection of the train data labelset and the val data labelset
         # is the training labelset. That labelset will be size 1 (only A),
         # thus fulfilling our test conditions.
-        for _ in range(settings.MIN_NBR_ANNOTATED_IMAGES):
+        for _ in range(settings.TRAINING_MIN_IMAGES):
             img = self.upload_image(
                 self.user, self.source, image_options=dict(
                     filename=f'train{self.image_count}.png'))

--- a/project/vision_backend/tests/tasks/test_train.py
+++ b/project/vision_backend/tests/tasks/test_train.py
@@ -4,7 +4,6 @@ from unittest import mock
 from django.conf import settings
 from django.core.files.storage import get_storage_class
 from django.test import override_settings
-import spacer.config as spacer_config
 from spacer.data_classes import ValResults
 from spacer.exceptions import SpacerInputError
 
@@ -23,10 +22,7 @@ class TrainClassifierTest(BaseTaskTest, JobUtilsMixin):
 
     def test_source_check(self):
         # Provide enough data for training. Extract features.
-        val_image_count = 1
-        self.upload_images_for_training(
-            train_image_count=spacer_config.MIN_TRAINIMAGES,
-            val_image_count=val_image_count)
+        self.upload_images_for_training()
         run_scheduled_jobs_until_empty()
         queue_and_run_collect_spacer_jobs()
 
@@ -46,7 +42,6 @@ class TrainClassifierTest(BaseTaskTest, JobUtilsMixin):
         # Provide enough data for training. Extract features.
         val_image_count = 1
         self.upload_images_for_training(
-            train_image_count=spacer_config.MIN_TRAINIMAGES,
             val_image_count=val_image_count)
         run_scheduled_jobs_until_empty()
         queue_and_run_collect_spacer_jobs()
@@ -113,8 +108,7 @@ class TrainClassifierTest(BaseTaskTest, JobUtilsMixin):
             self_.runtime = runtime
 
         # Provide enough data for training. Extract features.
-        self.upload_images_for_training(
-            train_image_count=spacer_config.MIN_TRAINIMAGES, val_image_count=1)
+        self.upload_images_for_training()
         run_scheduled_jobs_until_empty()
         queue_and_run_collect_spacer_jobs()
         # Submit classifier.
@@ -129,7 +123,7 @@ class TrainClassifierTest(BaseTaskTest, JobUtilsMixin):
         clf_1 = self.source.get_current_classifier()
 
         # Upload enough additional images for the next training to happen.
-        old_image_count = spacer_config.MIN_TRAINIMAGES + 1
+        old_image_count = settings.MIN_NBR_ANNOTATED_IMAGES + 1
         new_image_count = math.ceil(
             old_image_count*settings.NEW_CLASSIFIER_TRAIN_TH)
         added_image_count = new_image_count - old_image_count
@@ -171,7 +165,7 @@ class TrainClassifierTest(BaseTaskTest, JobUtilsMixin):
             'train.png', with_labels=True)
         # Other annotated images to get enough for training
         self.upload_images_for_training(
-            train_image_count=spacer_config.MIN_TRAINIMAGES-1,
+            train_image_count=settings.MIN_NBR_ANNOTATED_IMAGES-1,
             val_image_count=0)
 
         # Extract features
@@ -239,8 +233,7 @@ class AbortCasesTest(BaseTaskTest, ErrorReportTestMixin, JobUtilsMixin):
     def test_classification_disabled(self):
         """Try to train for a source which has classification disabled."""
         # Ensure the source is otherwise ready for training.
-        self.upload_images_for_training(
-            train_image_count=spacer_config.MIN_TRAINIMAGES, val_image_count=1)
+        self.upload_images_for_training()
         # Extract features
         run_scheduled_jobs_until_empty()
         queue_and_run_collect_spacer_jobs()
@@ -264,13 +257,12 @@ class AbortCasesTest(BaseTaskTest, ErrorReportTestMixin, JobUtilsMixin):
         training.
         """
         # Prepare some training images + features.
-        self.upload_images_for_training(
-            train_image_count=spacer_config.MIN_TRAINIMAGES, val_image_count=1)
+        self.upload_images_for_training()
         run_scheduled_jobs_until_empty()
         queue_and_run_collect_spacer_jobs()
 
         # But set CoralNet's requirement 1 higher than that image count.
-        min_images = spacer_config.MIN_TRAINIMAGES + 2
+        min_images = self.source.image_set.count() + 1
 
         with override_settings(MIN_NBR_ANNOTATED_IMAGES=min_images):
             # Check source
@@ -288,8 +280,7 @@ class AbortCasesTest(BaseTaskTest, ErrorReportTestMixin, JobUtilsMixin):
         since the last training.
         """
         # Prepare training images + features, and train one classifier.
-        self.upload_images_for_training(
-            train_image_count=spacer_config.MIN_TRAINIMAGES, val_image_count=1)
+        self.upload_images_for_training()
         run_scheduled_jobs_until_empty()
         queue_and_run_collect_spacer_jobs()
         run_scheduled_jobs_until_empty()
@@ -298,7 +289,7 @@ class AbortCasesTest(BaseTaskTest, ErrorReportTestMixin, JobUtilsMixin):
         # Attempt to train another classifier without adding more images.
         run_scheduled_jobs_until_empty()
 
-        image_count = spacer_config.MIN_TRAINIMAGES + 1
+        image_count = self.source.get_current_classifier().nbr_train_images
         threshold = math.ceil(image_count * settings.NEW_CLASSIFIER_TRAIN_TH)
         self.assert_job_result_message(
             'check_source',
@@ -316,7 +307,7 @@ class AbortCasesTest(BaseTaskTest, ErrorReportTestMixin, JobUtilsMixin):
         # The intersection of the train data labelset and the val data labelset
         # is the training labelset. That labelset will be size 1 (only A),
         # thus fulfilling our test conditions.
-        for _ in range(spacer_config.MIN_TRAINIMAGES):
+        for _ in range(settings.MIN_NBR_ANNOTATED_IMAGES):
             img = self.upload_image(
                 self.user, self.source, image_options=dict(
                     filename=f'train{self.image_count}.png'))
@@ -353,8 +344,7 @@ class AbortCasesTest(BaseTaskTest, ErrorReportTestMixin, JobUtilsMixin):
 
     def test_spacer_error(self):
         # Prepare training images + features.
-        self.upload_images_for_training(
-            train_image_count=spacer_config.MIN_TRAINIMAGES, val_image_count=1)
+        self.upload_images_for_training()
         run_scheduled_jobs_until_empty()
         queue_and_run_collect_spacer_jobs()
 
@@ -385,8 +375,7 @@ class AbortCasesTest(BaseTaskTest, ErrorReportTestMixin, JobUtilsMixin):
 
     def test_spacer_input_error(self):
         # Prepare training images + features.
-        self.upload_images_for_training(
-            train_image_count=spacer_config.MIN_TRAINIMAGES, val_image_count=1)
+        self.upload_images_for_training()
         run_scheduled_jobs_until_empty()
         queue_and_run_collect_spacer_jobs()
 
@@ -411,8 +400,7 @@ class AbortCasesTest(BaseTaskTest, ErrorReportTestMixin, JobUtilsMixin):
         Run the train task, then delete the classifier from the DB, then
         try to collect the train result.
         """
-        self.upload_images_for_training(
-            train_image_count=spacer_config.MIN_TRAINIMAGES, val_image_count=1)
+        self.upload_images_for_training()
         # Extract features.
         run_scheduled_jobs_until_empty()
         queue_and_run_collect_spacer_jobs()
@@ -444,15 +432,14 @@ class AbortCasesTest(BaseTaskTest, ErrorReportTestMixin, JobUtilsMixin):
             self_.runtime = runtime
 
         # Train one classifier.
-        self.upload_images_for_training(
-            train_image_count=spacer_config.MIN_TRAINIMAGES, val_image_count=1)
+        self.upload_images_for_training()
         run_scheduled_jobs_until_empty()
         queue_and_run_collect_spacer_jobs()
         run_scheduled_jobs_until_empty()
         queue_and_run_collect_spacer_jobs()
 
         # Upload enough additional images for the next training to happen.
-        old_image_count = spacer_config.MIN_TRAINIMAGES + 1
+        old_image_count = self.source.get_current_classifier().nbr_train_images
         new_image_count = math.ceil(
             old_image_count*settings.NEW_CLASSIFIER_TRAIN_TH)
         added_image_count = new_image_count - old_image_count

--- a/project/vision_backend/tests/tasks/utils.py
+++ b/project/vision_backend/tests/tasks/utils.py
@@ -51,7 +51,7 @@ class BaseTaskTest(ClientTest, UploadAnnotationsCsvTestMixin):
     ):
         if not train_image_count:
             # Provide enough data for initial training
-            train_image_count = settings.MIN_NBR_ANNOTATED_IMAGES
+            train_image_count = settings.TRAINING_MIN_IMAGES
 
         train_images = []
         val_images = []

--- a/project/vision_backend/tests/tasks/utils.py
+++ b/project/vision_backend/tests/tasks/utils.py
@@ -1,6 +1,6 @@
+from django.conf import settings
 from django.core.files.storage import get_storage_class
 from django.test import override_settings
-import spacer.config as spacer_config
 
 from images.model_utils import PointGen
 from jobs.tests.utils import do_job, queue_and_run_job
@@ -13,8 +13,6 @@ def queue_and_run_collect_spacer_jobs():
 
 
 @override_settings(
-    # Note that spacer also has its own minimum image count for training.
-    MIN_NBR_ANNOTATED_IMAGES=1,
     SPACER_QUEUE_CHOICE='vision_backend.queues.LocalQueue',
     # Sometimes it helps to run certain periodic jobs (particularly
     # collect_spacer_jobs) only when we explicitly want to.
@@ -48,7 +46,13 @@ class BaseTaskTest(ClientTest, UploadAnnotationsCsvTestMixin):
         return img
 
     @classmethod
-    def upload_images_for_training(cls, train_image_count, val_image_count):
+    def upload_images_for_training(
+        cls, train_image_count=None, val_image_count=1,
+    ):
+        if not train_image_count:
+            # Provide enough data for initial training
+            train_image_count = settings.MIN_NBR_ANNOTATED_IMAGES
+
         train_images = []
         val_images = []
 
@@ -65,10 +69,6 @@ class BaseTaskTest(ClientTest, UploadAnnotationsCsvTestMixin):
 
     @classmethod
     def upload_data_and_train_classifier(cls, new_train_images_count=None):
-        if not new_train_images_count:
-            # Provide enough data for initial training
-            new_train_images_count = spacer_config.MIN_TRAINIMAGES
-
         train_images, val_images = cls.upload_images_for_training(
             train_image_count=new_train_images_count, val_image_count=1)
         # Extract features

--- a/project/vision_backend/tests/test_queues.py
+++ b/project/vision_backend/tests/test_queues.py
@@ -3,7 +3,6 @@ import json
 from unittest import mock
 
 from django.test.utils import override_settings
-import spacer.config as spacer_config
 from spacer.messages import DataLocation, JobMsg
 from spacer.tasks import process_job
 
@@ -136,9 +135,7 @@ class QueueBasicTest(BaseTaskTest, JobUtilsMixin):
         self.assertTrue(img.features.extracted)
 
     def do_test_collect_training(self):
-        self.upload_images_for_training(
-            train_image_count=spacer_config.MIN_TRAINIMAGES,
-            val_image_count=1)
+        self.upload_images_for_training()
         # Feature extraction
         run_scheduled_jobs_until_empty()
         queue_and_run_collect_spacer_jobs()
@@ -223,9 +220,7 @@ class BatchQueueBasicTest(QueueBasicTest):
 
     def test_training_fail(self):
         """A training job can't be collected."""
-        self.upload_images_for_training(
-            train_image_count=spacer_config.MIN_TRAINIMAGES,
-            val_image_count=1)
+        self.upload_images_for_training()
 
         with mock_boto_client():
             # Feature extraction

--- a/project/vision_backend_api/tests/utils.py
+++ b/project/vision_backend_api/tests/utils.py
@@ -3,9 +3,9 @@ from io import BytesIO
 import math
 from unittest import mock
 
+from django.conf import settings
 from django.test import override_settings
 from django.urls import reverse
-from spacer.config import MIN_TRAINIMAGES
 
 from api_core.tests.utils import BaseAPITest
 from images.model_utils import PointGen
@@ -15,9 +15,7 @@ from lib.tests.utils import create_sample_image
 from vision_backend.tests.tasks.utils import queue_and_run_collect_spacer_jobs
 
 
-@override_settings(
-    MIN_NBR_ANNOTATED_IMAGES=1,
-    ENABLE_PERIODIC_JOBS=False)
+@override_settings(ENABLE_PERIODIC_JOBS=False)
 class DeployBaseTest(BaseAPITest, metaclass=ABCMeta):
 
     @classmethod
@@ -81,8 +79,8 @@ class DeployBaseTest(BaseAPITest, metaclass=ABCMeta):
         # Must have at least 2 unique labels in training data in order to
         # be accepted by spacer.
         annotations = {1: 'A_mycode', 2: 'B_mycode'}
-        num_validation_images = math.ceil(MIN_TRAINIMAGES / 8)
-        for i in range(MIN_TRAINIMAGES):
+        num_validation_images = math.ceil(settings.MIN_NBR_ANNOTATED_IMAGES / 8)
+        for i in range(settings.MIN_NBR_ANNOTATED_IMAGES):
             img = cls.upload_image(
                 cls.user, cls.source, dict(filename=f'train{i}.png'))
             cls.add_annotations(cls.user, img, annotations)

--- a/project/vision_backend_api/tests/utils.py
+++ b/project/vision_backend_api/tests/utils.py
@@ -79,8 +79,8 @@ class DeployBaseTest(BaseAPITest, metaclass=ABCMeta):
         # Must have at least 2 unique labels in training data in order to
         # be accepted by spacer.
         annotations = {1: 'A_mycode', 2: 'B_mycode'}
-        num_validation_images = math.ceil(settings.MIN_NBR_ANNOTATED_IMAGES / 8)
-        for i in range(settings.MIN_NBR_ANNOTATED_IMAGES):
+        num_validation_images = math.ceil(settings.TRAINING_MIN_IMAGES / 8)
+        for i in range(settings.TRAINING_MIN_IMAGES):
             img = cls.upload_image(
                 cls.user, cls.source, dict(filename=f'train{i}.png'))
             cls.add_annotations(cls.user, img, annotations)


### PR DESCRIPTION
MIN_NBR_ANNOTATED_IMAGES:

- Is now tied to the corresponding pyspacer setting (configurable starting in pyspacer 0.4.1).
- Can now be set to a really low number (like 2) to speed up classifier-related tests. Note that the setting doesn't propagate with override_settings(), so you can't (readily) have it set to a high number in your env while still using a low number in tests.
- Is now named TRAINING_MIN_IMAGES, to fit better with other setting names such as FILE_UPLOAD_MAX_MEMORY_SIZE.

MAX_POINTS_PER_IMAGE:

- Is now tied to the corresponding pyspacer setting (configurable starting in pyspacer 0.4.1).
- Is now enforced when uploading points+annotations by CSV or CPC (issue #315).
- Is now referenced by the new/edit source form, instead of the form having its own defined threshold.