### PR TITLE
Make Backend Overview somewhat leaner and paginated

### DIFF
--- a/project/api_management/templates/api_management/job_detail.html
+++ b/project/api_management/templates/api_management/job_detail.html
@@ -6,16 +6,16 @@
 {% block css-code %}
 <style>
 tr[data-status="{{ PENDING }}"] {
-  background-color: #bbe;
+  background-color: var(--status-color-pending);
 }
 tr[data-status="{{ IN_PROGRESS }}"] {
-  background-color: #eeb;
+  background-color: var(--status-color-in-progress);
 }
 tr[data-status="{{ SUCCESS }}"] {
-  background-color: #beb;
+  background-color: var(--status-color-done);
 }
 tr[data-status="{{ FAILURE }}"] {
-  background-color: #ebb;
+  background-color: var(--status-color-failure);
 }
 </style>
 {% endblock %}

--- a/project/api_management/templates/api_management/job_list.html
+++ b/project/api_management/templates/api_management/job_list.html
@@ -6,16 +6,16 @@
 {% block css-code %}
 <style>
 tr[data-status="{{ PENDING }}"] {
-  background-color: #bbe;
+  background-color: var(--status-color-pending);
 }
 tr[data-status="{{ IN_PROGRESS }}"] {
-  background-color: #eeb;
+  background-color: var(--status-color-in-progress);
 }
 tr[data-status="{{ DONE }}"] {
-  background-color: #beb;
+  background-color: var(--status-color-done);
 }
 td.failure {
-  background-color: #ebb;
+  background-color: var(--status-color-failure);
 }
 </style>
 {% endblock %}

--- a/project/jobs/static/css/jobs.css
+++ b/project/jobs/static/css/jobs.css
@@ -5,20 +5,20 @@
 
 #job-summary td.pending,
 #job-table tr.pending {
-  background-color: #bbe;
+  background-color: var(--status-color-pending);
 }
 #job-summary td.in_progress,
 #job-table tr.in_progress {
-  background-color: #eeb;
+  background-color: var(--status-color-in-progress);
 }
 #job-table tr.success {
-  background-color: #beb;
+  background-color: var(--status-color-done);
 }
 #job-table tr.failure {
-  background-color: #ebb;
+  background-color: var(--status-color-failure);
 }
 #job-summary td.completed {
-  background-color: #beb;
+  background-color: var(--status-color-done);
 }
 
 #job-table td.source,

--- a/project/static/css/master.css
+++ b/project/static/css/master.css
@@ -20,6 +20,11 @@ margin: spacing around the outside of an element.
 :root {
   --link-color: hsl(6, 100%, 27%);
   --main-font: 'Droid Sans', helvetica, arial, Geneva, sans-serif;
+
+  --status-color-pending: #bbe;
+  --status-color-in-progress: #eeb;
+  --status-color-done: #beb;
+  --status-color-failure: #ebb;
 }
 
 

--- a/project/vision_backend/templates/vision_backend/overview.html
+++ b/project/vision_backend/templates/vision_backend/overview.html
@@ -1,6 +1,21 @@
 {% extends "base.html" %}
 
 
+{% block css-code %}
+<style>
+tr.source-row.needs_check {
+  background-color: var(--status-color-pending);
+}
+tr.source-row.caught_up {
+  background-color: var(--status-color-done);
+}
+tr.source-row.needs_processing {
+  background-color: var(--status-color-in-progress);
+}
+</style>
+{% endblock %}
+
+
 {% block content %}
 
 <table class="detail_table" id="image-counts-table">
@@ -44,45 +59,45 @@
   There are {{clf_stats.nclassifiers}} trained classifiers out of which {{clf_stats.nacceptedclassifiers}} are accepted. This means there are on average {{clf_stats.accepted_ratio}} accepted classifiers per each of the {{clf_stats.nsources}} sources.
 </div>
 
-<table class="detail_table_popup" id="sources-table">
+<br><br>
+
+<h2>Sources</h2>
+
+<div class="line">
+  Note: Sources with "Queued ... image classification(s)" which are colored as in-progress may actually be done processing instead.
+</div>
+
+<table class="generic" id="sources-table">
   <thead>
     <tr>
-      <th>id</th>
-      <th>name</th>
-      <th># ver rbts</th>
-      <th># rbts</th>
-      <th>need new</th>
-      <th># imgs</th>
-      <th># ver.</th>
-      <th># in curr.</th>
-      <th># need feats</th>
-      <th># uncl.</th>
+      <th>ID</th>
+      <th>Name</th>
+      <th># Imgs</th>
+      <th># Conf.</th>
+      <th># In clf</th>
+      <th>Last check</th>
     </tr>
   </thead>
   <tbody>
-    {% for source in laundry_list %}
-      <tr
-        {% if source.need_attention %}
-          style="background-color:red;color:#000"
-        {% elif source.has_robot %}
-          style="background-color:green;color:#000"
-        {% else %}
-          style="background-color:gray;color:#000"
-        {% endif %}
-      >
-        <td> <a href="{% url 'source_main' source.id %}">{{source.id}}</a> </td>
-        <td> {{source.name_short}} </td>
-        <td> {{source.nbr_accepted_robots}} </td>
-        <td> {{source.nbr_robots}} </td>
-        <td> {{source.need_robot}} </td>
-        <td> {{source.nbr_total_images}} </td>
-        <td> {{source.nbr_human_annotated_images}} </td>
-        <td> {{source.nbr_in_current_model}} </td>
-        <td> {{source.nbr_images_needs_features}} </td>
-        <td> {{source.nbr_unclassified_images}} </td>
+    {% for source in page_sources %}
+      <tr class="source-row {{ source.status }}">
+        <td>
+          <a href="{% url 'source_main' source.pk %}">{{ source.pk }}</a>
+        </td>
+        <td>
+          <span title="{{ source.name }}">
+            {{ source.name|truncatechars:40 }}
+          </span>
+        </td>
+        <td>{{ source.image_count }}</td>
+        <td>{{ source.confirmed_image_count }}</td>
+        <td>{{ source.classifier_image_count }}</td>
+        <td>{{ source.check_message }}</td>
       </tr>
     {% endfor %}
   </tbody>
 </table>
+
+{% include 'pagination_links.html' with page_results=page_results %}
 
 {% endblock %}

--- a/project/vision_backend/tests/test_views.py
+++ b/project/vision_backend/tests/test_views.py
@@ -185,7 +185,8 @@ class BackendOverviewTest(ClientTest, HtmlAssertionsMixin):
 
     def test(self):
         """
-        This test is somewhat haphazard and doesn't test all cases.
+        This test is somewhat haphazard and definitely doesn't test all
+        cases/values.
         """
         image1a = self.upload_image(self.user, self.source1)
         image1b = self.upload_image(self.user, self.source1)
@@ -222,28 +223,24 @@ class BackendOverviewTest(ClientTest, HtmlAssertionsMixin):
             'table#sources-table')[0]
         self.assert_table_values(sources_table_soup, [
             {
-                "id": (
+                "ID": (
                     f'<a href="'
                     f'{reverse("source_main", args=[self.source2.pk])}">'
                     f'{self.source2.pk}'
                     f'</a>'
                 ),
-                "# imgs": 3,
-                "# ver.": 1,
-                "# need feats": 3,
-                "# uncl.": 0,
+                "# Imgs": 3,
+                "# Conf.": 1,
             },
             {
-                "id": (
+                "ID": (
                     f'<a href="'
                     f'{reverse("source_main", args=[self.source1.pk])}">'
                     f'{self.source1.pk}'
                     f'</a>'
                 ),
-                "# imgs": 4,
-                "# ver.": 2,
-                "# need feats": 3,
-                "# uncl.": 2,
+                "# Imgs": 4,
+                "# Conf.": 2,
             },
         ])
 


### PR DESCRIPTION
So that it loads much faster (was taking several minutes before).

In a rush to get this out now, so the changes are unpolished in some ways. For example: "Note: Sources with "Queued ... image classification(s)" which are colored as in-progress may actually be done processing instead."