### PR TITLE
Map: Catch non-numeric lat/long on the Javascript side

### DIFF
--- a/project/map/static/js/map.js
+++ b/project/map/static/js/map.js
@@ -87,6 +87,9 @@ class SourcesMap {
         for (let source of mapSources) {
             let latitude = Number(source['latitude']);
             let longitude = Number(source['longitude']);
+            if (isNaN(latitude) || isNaN(longitude)) {
+                continue;
+            }
 
             // 'Main' marker.
             let coordinateSets = [[latitude, longitude]];


### PR DESCRIPTION
This does indicate lat/long values that could be tracked down and corrected, but good to code defensively on the JS side anyway.