### PR TITLE
Various jobs fixes

### DIFF
--- a/project/jobs/tests/test_utils.py
+++ b/project/jobs/tests/test_utils.py
@@ -291,7 +291,7 @@ class JobDecoratorTest(BaseTest, ErrorReportTestMixin, EmailAssertionsMixin):
             "A ValueError",
         )
         self.assert_latest_email(
-            "Error in task: full_job_example",
+            "Error in job: full_job_example",
             ["ValueError: A ValueError"],
         )
 
@@ -331,7 +331,7 @@ class JobDecoratorTest(BaseTest, ErrorReportTestMixin, EmailAssertionsMixin):
             "A ValueError",
         )
         self.assert_latest_email(
-            "Error in task: job_runner_example",
+            "Error in job: job_runner_example",
             ["ValueError: A ValueError"],
         )
 
@@ -372,7 +372,7 @@ class JobDecoratorTest(BaseTest, ErrorReportTestMixin, EmailAssertionsMixin):
             f"A ValueError (ID: {job.pk})",
         )
         self.assert_latest_email(
-            "Error in task: job_starter_example",
+            "Error in job: job_starter_example",
             [f"ValueError: A ValueError (ID: {job.pk})"],
         )
 

--- a/project/vision_backend/exceptions.py
+++ b/project/vision_backend/exceptions.py
@@ -1,0 +1,2 @@
+class RowColumnMismatchError(Exception):
+    pass

--- a/project/vision_backend/task_helpers.py
+++ b/project/vision_backend/task_helpers.py
@@ -30,6 +30,7 @@ from jobs.exceptions import JobError
 from jobs.models import Job
 from jobs.utils import finish_job
 from labels.models import Label, LabelSet
+from .exceptions import RowColumnMismatchError
 from .models import Classifier, Score
 from .utils import queue_source_check
 
@@ -74,9 +75,15 @@ def add_annotations(image_id: int,
     for itt, point in enumerate(points):
         if res.valid_rowcol:
             # Retrieve score vector for (row, column) location
-            scores = res[(point.row, point.column)]
+            try:
+                scores = res[(point.row, point.column)]
+            except KeyError:
+                raise RowColumnMismatchError
         else:
-            _, _, scores = res.scores[itt]
+            try:
+                _, _, scores = res.scores[itt]
+            except IndexError:
+                raise RowColumnMismatchError
         label = label_objs[int(np.argmax(scores))]
 
         result = Annotation.objects.update_point_annotation_if_applicable(
@@ -117,13 +124,19 @@ def add_scores(image_id: int,
 
     # Now, go through and create new ones.
     points = Point.objects.filter(image=img).order_by('id')
-    
+
     score_objs = []
     for itt, point in enumerate(points):
         if res.valid_rowcol:
-            scores = res[(point.row, point.column)]
+            try:
+                scores = res[(point.row, point.column)]
+            except KeyError:
+                raise RowColumnMismatchError
         else:
-            _, _, scores = res.scores[itt]
+            try:
+                _, _, scores = res.scores[itt]
+            except IndexError:
+                raise RowColumnMismatchError
         inds = np.argsort(scores)[::-1][:nbr_scores]
         for ind in inds:
             score_objs.append(

--- a/project/vision_backend/task_helpers.py
+++ b/project/vision_backend/task_helpers.py
@@ -189,12 +189,17 @@ class SpacerResultHandler(ABC):
             # Last line of the traceback should serve as a decent
             # one-line summary. Has the error class and message.
             error_message = error_traceback.splitlines()[-1]
-            # The error message should be like
-            # `somemodule.SomeError: some error info`.
+            # The error message should be either like:
+            # 1) `somemodule.SomeError: some error info`.
             # We extract the error class/info as the part before/after
             # the first colon.
-            error_class, error_info = error_message.split(':', maxsplit=1)
-            error_info = error_info.strip()
+            # 2) `AssertionError`. Just a class, no colon, no detail.
+            if ':' in error_message:
+                error_class, error_info = error_message.split(':', maxsplit=1)
+                error_info = error_info.strip()
+            else:
+                error_class = error_message
+                error_info = ""
 
             if error_class != 'spacer.exceptions.SpacerInputError':
                 # Not a SpacerInputError, so we should treat it like


### PR DESCRIPTION
The 2nd and 4th commits' fixes are really annoying me because they feel like band-aid layers over ugly, race-condition-compensating code. There's also a chance that I'll have to completely rework both sections of code sooner rather than later.

Overall, this CoralNet 1.7(.x) release is designed to be louder about failures than previous releases. Which is good for the long run, but can definitely weigh down on me in the short run.