### PR TITLE
Switch from Django's FileBasedCache to 3rd-party DiskCache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ For general instructions on how to update a development environment of CoralNet,
 For info about the semantic versioning used here, see `docs/versions.rst`.
 
 
-## 1.7.1 (WIP)
+## 1.8 (WIP)
 
 - New migration to run for `jobs`. If `api_core` 0004 runs into issues, try running the new `jobs` 0011 migration first.
+- New package to install: diskcache 5.6.3
+- Clear the current contents of the Django cache folder (`<SITE_DIR>/tmp/django_cache` by default). The format of cache files saved to this directory will be different from before.
+- The `update_label_details` periodic-job should be run at least once to compute labels' annotation counts and popularities.
 
 ## [1.7](https://github.com/coralnet/coralnet/tree/1.7)
 

--- a/project/lib/tests/test_misc.py
+++ b/project/lib/tests/test_misc.py
@@ -1,10 +1,6 @@
 # Lib tests and non-app-specific tests.
-import datetime
 from email.utils import parseaddr
 from unittest import skip, skipIf
-from urllib.error import HTTPError
-from urllib.parse import parse_qs, urlencode, urlsplit, urlunsplit
-import urllib.request
 
 from django.conf import settings
 from django.core.files.storage import DefaultStorage
@@ -121,105 +117,6 @@ class IndexTest(ClientTest):
             # Check for correct carousel image count.
             self.assertEqual(
                 len(list(response.context['carousel_images'])), 3)
-
-
-@skipIf(not settings.DEFAULT_FILE_STORAGE == 'lib.storage_backends.MediaStorageS3', "Requires S3 storage")
-class S3UrlAccessTest(ClientTest):
-    """
-    Test accessing uploaded S3 objects by URL.
-    """
-    @classmethod
-    def setUpTestData(cls):
-        super().setUpTestData()
-
-        cls.user = cls.create_user()
-        cls.source = cls.create_source(cls.user)
-
-        # Upload an image using django-storages + boto.
-        cls.img = cls.upload_image(
-            cls.user, cls.source, image_options=dict(filename='1.png'))
-
-    def assert_forbidden(self, url, msg):
-        with self.assertRaises(HTTPError) as cm:
-            urllib.request.urlopen(url)
-        self.assertEqual(cm.exception.code, 403, msg)
-
-    def test_image_url_query_args(self):
-        url = self.img.original_file.url
-        current_timestamp = datetime.datetime.now().timestamp()
-        query_string = urlsplit(url).query
-        query_args = parse_qs(query_string)
-
-        self.assertIn('AWSAccessKeyId', query_args, "Should have an access key")
-        self.assertIn('Expires', query_args, "Should have an expire time")
-        self.assertIn('Signature', query_args, "Should have a signature")
-
-        expire_timestamp = int(query_args['Expires'][0])
-        self.assertGreaterEqual(
-            expire_timestamp, current_timestamp + 3300,
-            "Expire time should be about 1 hour into the future")
-        self.assertLessEqual(
-            expire_timestamp, current_timestamp + 3900,
-            "Expire time should be about 1 hour into the future")
-
-    def test_image_url_allowed_access(self):
-        url = self.img.original_file.url
-        base_url = urlunsplit(urlsplit(url)._replace(query=''))
-        query_string = urlsplit(url).query
-        query_args = parse_qs(query_string)
-
-        response = urllib.request.urlopen(url)
-        self.assertEqual(
-            response.status, 200, "Getting the URL should work")
-        self.assertEqual(
-            response.headers['Content-Type'], 'image/png',
-            "URL response should have the expected content type")
-
-        alt_query_args = query_args.copy()
-        alt_query_args.pop('AWSAccessKeyId')
-        self.assert_forbidden(
-            base_url + '?' + urlencode(alt_query_args),
-            "Getting the URL without the access key shouldn't work")
-
-        alt_query_args = query_args.copy()
-        alt_query_args.pop('Expires')
-        self.assert_forbidden(
-            base_url + '?' + urlencode(alt_query_args),
-            "Getting the URL without the expire time shouldn't work")
-
-        alt_query_args = query_args.copy()
-        alt_query_args.pop('Signature')
-        self.assert_forbidden(
-            base_url + '?' + urlencode(alt_query_args),
-            "Getting the URL without the signature shouldn't work")
-
-        self.assert_forbidden(
-            base_url,
-            "Getting the URL without any query args shouldn't work")
-
-        alt_query_args = query_args.copy()
-        alt_query_args['AWSAccessKeyId'][0] = \
-            alt_query_args['AWSAccessKeyId'][0].replace(
-                alt_query_args['AWSAccessKeyId'][0][5], 'X')
-        self.assert_forbidden(
-            base_url + '?' + urlencode(alt_query_args),
-            "Getting the URL with a modified access key shouldn't work")
-
-        alt_query_args = query_args.copy()
-        alt_query_args['Expires'][0] = \
-            alt_query_args['Expires'][0].replace(
-                alt_query_args['Expires'][0][5], '0')
-        self.assert_forbidden(
-            base_url + '?' + urlencode(alt_query_args),
-            "Getting the URL with a modified expire time shouldn't work")
-
-        alt_query_args = query_args.copy()
-        alt_query_args['Signature'][0] = \
-            alt_query_args['Signature'][0].replace(
-                alt_query_args['Signature'][0][5], 'X')
-        self.assert_forbidden(
-            base_url + '?' + urlencode(alt_query_args),
-            "Getting the URL with a modified signature shouldn't work")
 
 
 class GoogleAnalyticsTest(ClientTest):

--- a/project/lib/tests/test_storage.py
+++ b/project/lib/tests/test_storage.py
@@ -1,0 +1,155 @@
+import datetime
+import time
+from unittest import skipIf
+from urllib.error import HTTPError
+from urllib.parse import parse_qs, urlencode, urlsplit, urlunsplit
+import urllib.request
+
+from django.conf import settings
+from django.core.cache import cache
+from django.test import override_settings
+
+from ..storage_backends import StorageManagerLocal
+from .utils import BaseTest, ClientTest
+
+
+@skipIf(
+    not settings.DEFAULT_FILE_STORAGE == 'lib.storage_backends.MediaStorageS3',
+    "Requires S3 storage")
+class S3UrlAccessTest(ClientTest):
+    """
+    Test accessing uploaded S3 objects by URL.
+    """
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.user = cls.create_user()
+        cls.source = cls.create_source(cls.user)
+
+        # Upload an image using django-storages + boto.
+        cls.img = cls.upload_image(
+            cls.user, cls.source, image_options=dict(filename='1.png'))
+
+    def assert_forbidden(self, url, msg):
+        with self.assertRaises(HTTPError) as cm:
+            urllib.request.urlopen(url)
+        self.assertEqual(cm.exception.code, 403, msg)
+
+    def test_image_url_query_args(self):
+        url = self.img.original_file.url
+        current_timestamp = datetime.datetime.now().timestamp()
+        query_string = urlsplit(url).query
+        query_args = parse_qs(query_string)
+
+        self.assertIn('AWSAccessKeyId', query_args, "Should have an access key")
+        self.assertIn('Expires', query_args, "Should have an expire time")
+        self.assertIn('Signature', query_args, "Should have a signature")
+
+        expire_timestamp = int(query_args['Expires'][0])
+        self.assertGreaterEqual(
+            expire_timestamp, current_timestamp + 3300,
+            "Expire time should be about 1 hour into the future")
+        self.assertLessEqual(
+            expire_timestamp, current_timestamp + 3900,
+            "Expire time should be about 1 hour into the future")
+
+    def test_image_url_allowed_access(self):
+        url = self.img.original_file.url
+        base_url = urlunsplit(urlsplit(url)._replace(query=''))
+        query_string = urlsplit(url).query
+        query_args = parse_qs(query_string)
+
+        response = urllib.request.urlopen(url)
+        self.assertEqual(
+            response.status, 200, "Getting the URL should work")
+        self.assertEqual(
+            response.headers['Content-Type'], 'image/png',
+            "URL response should have the expected content type")
+
+        alt_query_args = query_args.copy()
+        alt_query_args.pop('AWSAccessKeyId')
+        self.assert_forbidden(
+            base_url + '?' + urlencode(alt_query_args),
+            "Getting the URL without the access key shouldn't work")
+
+        alt_query_args = query_args.copy()
+        alt_query_args.pop('Expires')
+        self.assert_forbidden(
+            base_url + '?' + urlencode(alt_query_args),
+            "Getting the URL without the expire time shouldn't work")
+
+        alt_query_args = query_args.copy()
+        alt_query_args.pop('Signature')
+        self.assert_forbidden(
+            base_url + '?' + urlencode(alt_query_args),
+            "Getting the URL without the signature shouldn't work")
+
+        self.assert_forbidden(
+            base_url,
+            "Getting the URL without any query args shouldn't work")
+
+        alt_query_args = query_args.copy()
+        alt_query_args['AWSAccessKeyId'][0] = \
+            alt_query_args['AWSAccessKeyId'][0].replace(
+                alt_query_args['AWSAccessKeyId'][0][5], 'X')
+        self.assert_forbidden(
+            base_url + '?' + urlencode(alt_query_args),
+            "Getting the URL with a modified access key shouldn't work")
+
+        alt_query_args = query_args.copy()
+        alt_query_args['Expires'][0] = \
+            alt_query_args['Expires'][0].replace(
+                alt_query_args['Expires'][0][5], '0')
+        self.assert_forbidden(
+            base_url + '?' + urlencode(alt_query_args),
+            "Getting the URL with a modified expire time shouldn't work")
+
+        alt_query_args = query_args.copy()
+        alt_query_args['Signature'][0] = \
+            alt_query_args['Signature'][0].replace(
+                alt_query_args['Signature'][0][5], 'X')
+        self.assert_forbidden(
+            base_url + '?' + urlencode(alt_query_args),
+            "Getting the URL with a modified signature shouldn't work")
+
+
+class CacheTest(BaseTest):
+
+    def test_cull_expired_items_on_set(self):
+        """
+        Unlike Django's FileBasedCache, DiskCache should cull expired cache
+        entries (in the same shard) when any other entry is set.
+        """
+        storage_manager = StorageManagerLocal()
+        cache_dir = storage_manager.create_temp_dir()
+
+        with override_settings(CACHES={
+            'default': {
+                'BACKEND': 'diskcache.DjangoCache',
+                'LOCATION': cache_dir,
+                # No partitioning of data so that eviction logic is easy to
+                # reason about.
+                'SHARDS': 1,
+                'DATABASE_TIMEOUT': 0.5,
+            }
+        }):
+            # Set a key that expires in 1 second.
+            cache.set(key='key1', value='1', timeout=1)
+            # Wait 2 seconds.
+            time.sleep(2)
+            # Setting any value should make the DiskCache backend look for
+            # expired entries to cull (within the same shard).
+            cache.set(key='key2', value='2', timeout=1000)
+
+            # expire() is part of the DiskCache backend. It removes expired
+            # items from the cache, and returns the number of items removed.
+            num_items_removed = cache.expire()
+            self.assertEqual(
+                num_items_removed, 0,
+                msg=f"{num_items_removed} item(s) removed. This shouldn't"
+                    f" remove any items, because key1 should already"
+                    f" have been evicted when setting key2",
+            )
+
+        storage_manager.remove_temp_dir(cache_dir)

--- a/project/lib/tests/utils.py
+++ b/project/lib/tests/utils.py
@@ -54,15 +54,10 @@ test_settings = dict()
 test_settings['STATICFILES_STORAGE'] = \
     'django.contrib.staticfiles.storage.StaticFilesStorage'
 
-# Use a local memory cache instead of a filesystem cache, because:
-# - In testing, there's no reason to persist the cache after a particular
-#   test is over. It's also more files we'd have to clean up after testing.
-# - By using the same file-based cache setting as the actual server, we
-#   clutter the actual server's cache folder with test cache files, which
-#   is strange at best (if not actually harmful). Also, there can be file
-#   access annoyances: if production/staging run the server as www-data,
-#   then tests on those instances may also have to run as www-data to
-#   access cache files.
+# For most tests, use a local memory cache instead of a filesystem cache,
+# because there's no reason to persist the cache after a particular test is
+# over. And having to clean up those files after each test is slower +
+# more issue-prone than just using memory.
 #
 # Note that the Django docs have a warning on overriding the CACHES setting.
 # For example, tests that use cached sessions may need some extra care.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -108,6 +108,12 @@ djangorestframework==3.14.0
 # https://github.com/plumdog/django_migration_testcase/
 django-migration-testcase==0.0.15
 
+# We use this as an alternative file-based Django cache backend, to avoid
+# certain issues of the first-party backend (mainly, culling entries
+# randomly).
+# https://github.com/grantjenks/python-diskcache
+diskcache==5.6.3
+
 # Character encoding detection.
 # Which is a hard problem, so we ask 2 different libraries for their opinions.
 # cchardet is a faster version of chardet, but is no longer maintained:


### PR DESCRIPTION
This should allow more sensible eviction logic for our cache usage, where we make one-time-use async media keys expire quickly, and make performance keys (e.g. label_details) expire very rarely.

Django's FileBasedCache backend would only consider a cache key's expire time if that particular cache key was queried. So for one-time keys, those keys would never get cleaned up until the cache got full. In the event it got full, FileBasedCache would evict 1/3 of entries randomly, without looking at expire time or anything.

The [DiskCache](https://github.com/grantjenks/python-diskcache/) backend looks for expired keys whenever any key is added, so expired keys are cleaned up much more proactively, which in our case at the moment, should mean the cache never gets full. But if it did get full, it would evict the least recently used entries, rather than random ones.

DiskCache also claims to have adding better optimized compared to FileBasedCache; FBC counts the files in the cache directory on every add to check for fullness, while DiskCache uses a SQLite database to implement a more efficient fullness check.

One downside to diskcache is that it's a 3rd-party package, and it also has no changelog, so changes must be inspected at the individual-commit level when updating the package in the future.