### PR TITLE
run_scheduled_jobs(): handle unrecognized job names

### DIFF
--- a/project/jobs/exceptions.py
+++ b/project/jobs/exceptions.py
@@ -4,3 +4,10 @@ class JobError(Exception):
     the code that cleans up after Jobs.
     """
     pass
+
+
+class UnrecognizedJobNameError(Exception):
+    """
+    A requested job name wasn't found in the registry
+    """
+    pass


### PR DESCRIPTION
If a job name is unrecognized, finish that job with failure status.

Previous behavior was to just crash. This would happen for old update_label_popularities jobs, because that job function was replaced by update_label_details.

Note about test_tasks.py: test_job_available() turned out to be unnecessary, because the test job defined here was already getting autodiscovered (at least during test runs) just like any of our other jobs. The job's been renamed from `test`, though, due to possibility of conflicting with other test jobs defined in the future.