### PR TITLE
Adjust data upload object limit settings

### DIFF
--- a/project/config/settings.py
+++ b/project/config/settings.py
@@ -271,7 +271,7 @@ DATA_UPLOAD_MAX_MEMORY_SIZE = 52428800  # 50 MB
 # Maximum number of GET/POST parameters that are parsed from a single request.
 # Due to metadata-edit not having an image limit yet, this needs to be quite
 # large (each image would have about 20 fields).
-DATA_UPLOAD_MAX_NUMBER_FIELDS = 1000000
+DATA_UPLOAD_MAX_NUMBER_FIELDS = 2500*20
 
 # [CoralNet settings]
 IMAGE_UPLOAD_MAX_FILE_SIZE = 30*1024*1024  # 30 MB

--- a/project/config/settings.py
+++ b/project/config/settings.py
@@ -273,6 +273,15 @@ DATA_UPLOAD_MAX_MEMORY_SIZE = 52428800  # 50 MB
 # large (each image would have about 20 fields).
 DATA_UPLOAD_MAX_NUMBER_FIELDS = 2500*20
 
+# Maximum number of files that may be received via POST in a
+# multipart/form-data encoded request before a SuspiciousOperation
+# (TooManyFiles) is raised.
+# Default 100.
+# Main concern for coralnet is CPC upload. Ideally that page would be reworked
+# so that files are uploaded in batches, rather than all in a single request.
+# But until then, we'll have a fairly high limit here.
+DATA_UPLOAD_MAX_NUMBER_FILES = 1000
+
 # [CoralNet settings]
 IMAGE_UPLOAD_MAX_FILE_SIZE = 30*1024*1024  # 30 MB
 IMAGE_UPLOAD_MAX_DIMENSIONS = (8000, 8000)


### PR DESCRIPTION
See commit messages. Both limits should actually be closer to their defaults and both pages of concern (metadata edit, CPC upload) should actually be reworked to not send so many fields/files. But that takes more effort, so that's for later.

When DATA_UPLOAD_MAX_NUMBER_FILES is crossed in CPC upload, it manifests as a 400 Bad Request. Offhand, I couldn't think of a clean way to make this show an informative error message to the user (like "you can only upload 1000 files in one go"). Right now, the Javascript alert only has something like: "There was an error: error / Bad Request". So that's another thing to consider for a later PR.