### PR TITLE
Try more encodings when decoding text files

### DIFF
--- a/project/upload/tests/test_utils.py
+++ b/project/upload/tests/test_utils.py
@@ -1,8 +1,7 @@
-from io import StringIO
+from io import BytesIO, StringIO
 
 from lib.tests.utils import BaseTest
-
-from ..utils import csv_to_dicts
+from ..utils import csv_to_dicts, text_file_to_unicode_stream
 
 
 class CsvToDictsTest(BaseTest):
@@ -61,3 +60,37 @@ class CsvToDictsTest(BaseTest):
         self.assertDictEqual(
             dicts[0], dict(a='1', b='2', c=''),
             msg="dict should have key for optional column")
+
+
+class TextFileToUnicodeTest(BaseTest):
+
+    def test_chinese_utf8(self):
+        byte_stream = BytesIO(
+            b'1.\xe5\xb0\x88\xe6\xa1\x88\xe8\xa8\x88\xe7\x95\xab\\'
+            b'10.\xe5\xbe\x8c\xe7\x81\xa3\xe4\xb8\xbb\xe9\xa1\x8c'
+            b'\xe8\xa8\x88\xe7\x95\xab\\20150610~11_HW'
+        )
+        unicode_stream = text_file_to_unicode_stream(byte_stream)
+        self.assertEqual(
+            unicode_stream.read(), '1.專案計畫\\10.後灣主題計畫\\20150610~11_HW')
+
+    def test_chinese_big5(self):
+        # This came up in production. chardet and charset-normalizer should
+        # agree on Big5. Fails to decode as utf-8.
+        byte_stream = BytesIO(
+            b'1.\xb1M\xae\xd7\xadp\xb5e\\'
+            b'10.\xab\xe1\xc6W\xa5D\xc3D\xadp\xb5e\\20140619~20_HW'
+        )
+        unicode_stream = text_file_to_unicode_stream(byte_stream)
+        self.assertEqual(
+            unicode_stream.read(), '1.專案計畫\\10.後灣主題計畫\\20140619~20_HW')
+
+    def test_xe9(self):
+        # This came up in production. chardet says ISO-8859-1,
+        # charset-normalizer says windows-1250, and fails to decode as utf-8.
+        # (Can decode as either of the first 2 guesses.)
+        byte_stream = BytesIO(
+            b'Tri\xe9\\1 H\xe9lice'
+        )
+        unicode_stream = text_file_to_unicode_stream(byte_stream)
+        self.assertEqual(unicode_stream.read(), 'Trié\\1 Hélice')


### PR DESCRIPTION
Previous logic was too quick to rely on utf-8. A chardet vs. charset-normalizer disagreement isn't the end of the world; some charsets are just quite similar. The `\xe9` test represents the case that was crashing in production with a UnicodeDecodeError recently (in an uploaded .cpc file).