### PR TITLE
Backend overview: image-counts summary separates sources with backend disabled

### DIFF
--- a/project/vision_backend/templates/vision_backend/overview.html
+++ b/project/vision_backend/templates/vision_backend/overview.html
@@ -48,6 +48,11 @@ tr.source-row.needs_processing {
       <td>{{ img_stats.pct_unclassified_without_features }}</td>
     </tr>
     <tr>
+      <td>Source has backend disabled</td>
+      <td>{{ img_stats.backend_disabled }}</td>
+      <td>{{ img_stats.pct_backend_disabled }}</td>
+    </tr>
+    <tr>
       <td>All</td>
       <td>{{ img_stats.total }}</td>
       <td>100.0%</td>

--- a/project/vision_backend/tests/test_views.py
+++ b/project/vision_backend/tests/test_views.py
@@ -216,6 +216,7 @@ class BackendOverviewTest(ClientTest, HtmlAssertionsMixin):
             ["Unconfirmed", "2", "28.6%"],
             ["Unclassified, with features", "1", "14.3%"],
             ["Unclassified, without features", "1", "14.3%"],
+            ["Source has backend disabled", "0", "0.0%"],
             ["All", "7", "100.0%"],
         ])
 

--- a/project/vision_backend/views.py
+++ b/project/vision_backend/views.py
@@ -22,12 +22,16 @@ from .utils import labelset_mapper, map_labels, get_alleviate
 def backend_overview(request):
     total = Image.objects.filter().count()
 
-    confirmed = Image.objects.confirmed().count()
-    unconfirmed = Image.objects.unconfirmed().count()
+    images_backend_enabled = \
+        Image.objects.filter(source__enable_robot_classifier=True)
+    confirmed = images_backend_enabled.confirmed().count()
+    unconfirmed = images_backend_enabled.unconfirmed().count()
     unclassified_with_features = \
-        Image.objects.unclassified().with_features().count()
+        images_backend_enabled.unclassified().with_features().count()
     unclassified_without_features = \
-        Image.objects.unclassified().without_features().count()
+        images_backend_enabled.unclassified().without_features().count()
+    backend_disabled = \
+        Image.objects.filter(source__enable_robot_classifier=False).count()
 
     def percent_display(numerator, denominator):
         return format(100*numerator / denominator, '.1f') + "%"
@@ -38,12 +42,14 @@ def backend_overview(request):
         'unconfirmed': unconfirmed,
         'unclassified_with_features': unclassified_with_features,
         'unclassified_without_features': unclassified_without_features,
+        'backend_disabled': backend_disabled,
         'pct_confirmed': percent_display(confirmed, total),
         'pct_unconfirmed': percent_display(unconfirmed, total),
         'pct_unclassified_with_features': percent_display(
             unclassified_with_features, total),
         'pct_unclassified_without_features': percent_display(
             unclassified_without_features, total),
+        'pct_backend_disabled': percent_display(backend_disabled, total),
     }
 
     all_sources = Source.objects.all()


### PR DESCRIPTION
Having the backend disabled for a particular source was only an available option in the old days, but it's still a functional option which is still enabled for some older sources. It does make the backend-overview image counts a bit misleading, though, and makes it hard to assess status on issue #413 for example. So this small PR addresses that.