### PR TITLE
Add management command to expedite pending jobs

### DIFF
--- a/project/jobs/management/commands/expedite_job.py
+++ b/project/jobs/management/commands/expedite_job.py
@@ -1,0 +1,28 @@
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from jobs.models import Job
+
+
+class Command(BaseCommand):
+    help = (
+        "Get pending Job instances by ID and set their start times to now."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'job_ids', type=int, nargs='+',
+            help="List of Job IDs to expedite")
+
+    def handle(self, *args, **options):
+        job_ids = options.get('job_ids')
+        for job_id in job_ids:
+            job = Job.objects.get(pk=job_id)
+            if job.status != Job.Status.PENDING:
+                self.stdout.write(
+                    f"Job {job_id} isn't pending; no action taken.")
+            else:
+                job.scheduled_start_date = timezone.now()
+                job.save()
+                self.stdout.write(
+                    f"Job {job_id} has been expedited.")

--- a/project/jobs/tests/test_commands.py
+++ b/project/jobs/tests/test_commands.py
@@ -1,12 +1,11 @@
+from datetime import timedelta
+
 from lib.tests.utils import ManagementCommandTest
 from ..models import Job
+from ..utils import queue_job
 
 
 class AbortJobTest(ManagementCommandTest):
-
-    @classmethod
-    def setUpTestData(cls):
-        super().setUpTestData()
 
     def test_abort(self):
         job_1 = Job(job_name='1')
@@ -35,3 +34,43 @@ class AbortJobTest(ManagementCommandTest):
             },
             "Only jobs 1 and 3 should have been aborted",
         )
+
+
+class ExpediteJobTest(ManagementCommandTest):
+
+    def test_expedite(self):
+        # Queue 3 jobs days into the future. 2 pending, 1 in progress.
+        job_1 = queue_job(
+            name='1', delay=timedelta(days=3))
+        job_2 = queue_job(
+            name='2', delay=timedelta(days=3),
+            initial_status=Job.Status.IN_PROGRESS)
+        job_3 = queue_job(
+            name='3', delay=timedelta(days=3))
+        original_start_dates = [
+            job_1.scheduled_start_date,
+            job_2.scheduled_start_date,
+            job_3.scheduled_start_date,
+        ]
+
+        # Try to expedite each job. Should work for the pending ones only.
+        stdout_text, _ = self.call_command_and_get_output(
+            'jobs', 'expedite_job', args=[job_1.pk, job_2.pk, job_3.pk])
+        self.assertIn(
+            f"Job {job_1.pk} has been expedited.", stdout_text)
+        self.assertIn(
+            f"Job {job_2.pk} isn't pending; no action taken.", stdout_text)
+        self.assertIn(
+            f"Job {job_3.pk} has been expedited.", stdout_text)
+
+        job_1.refresh_from_db()
+        job_2.refresh_from_db()
+        job_3.refresh_from_db()
+        new_start_dates = [
+            job_1.scheduled_start_date,
+            job_2.scheduled_start_date,
+            job_3.scheduled_start_date,
+        ]
+        self.assertLess(new_start_dates[0], original_start_dates[0])
+        self.assertEqual(new_start_dates[1], original_start_dates[1])
+        self.assertLess(new_start_dates[2], original_start_dates[2])


### PR DESCRIPTION
This bypasses the `queue_job()` check which sees if the same job had been failing repeatedly (and delays the job by 3 days if so). So one situation where this command should be useful is when we expect a repeatedly-failing job to succeed next time due to a fix, and we want to confirm that success immediately instead of waiting 3 days.