### PR TITLE
Include gunicorn [gthread] extra in requirements

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,4 +1,5 @@
--r base.txt # includes the base.txt requirements file
+# Include the base.txt requirements file
+-r base.txt
 
 
 # Output info on test coverage - how much of the Python codebase is covered

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,6 +1,8 @@
--r base.txt # includes the base.txt requirements file
+# Include the base.txt requirements file
+-r base.txt
+
 
 # WSGI HTTP server - The layer above Django, and below the overall web
 # server (e.g. nginx)
 # Changelog: http://docs.gunicorn.org/en/stable/news.html
-gunicorn>=20.1.0,<20.2
+gunicorn[gthread]>=20.1.0,<20.2


### PR DESCRIPTION
Technically our requirements should do this since we use gthread workers. Although it doesn't currently make a difference because, if you check gunicorn's [pyproject.toml](https://github.com/benoitc/gunicorn/blob/5e30bfa6b1a3e1f2bde7feb514d1734d28f39231/pyproject.toml) (or formerly [setup.py](https://github.com/benoitc/gunicorn/blob/20.1.0/setup.py)), the [gthread] extra doesn't add any packages.

The [gthread] extra is presumably defined for future-proofing in case gthread does require additional packages later, and also for consistency with the other non-default worker types which do have non-empty extras.

Relatedly, I was tempted to bump the gunicorn version from 20.1.0 to 21.x, but I wasn't able to determine if the [changes](https://docs.gunicorn.org/en/latest/2023-news.html) were beneficial for gthread users or not. The main gthread related fix had two people chime in after the updates to say they were still seeing the issue. Besides that, there were a couple of regressions that were fixed in subsequent minor versions. I'm inclined to be a bit cautious with server-process changes and try to only roll out one change at a time (I have a different change in mind for this cycle).