### PR TITLE
Set django-storages AWS_S3_USE_THREADS to False

### DIFF
--- a/project/config/settings.py
+++ b/project/config/settings.py
@@ -425,6 +425,14 @@ AWS_BATCH_REGION = env('AWS_BATCH_REGION', default='us-west-2')
 # http://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html
 AWS_ACCESS_KEY_ID = env('AWS_ACCESS_KEY_ID', default=None)
 AWS_SECRET_ACCESS_KEY = env('AWS_SECRET_ACCESS_KEY', default=None)
+# Added in 1.13; disables using threads for S3 requests, preventing errors
+# such as
+# `RuntimeError: cannot schedule new futures after interpreter shutdown`
+# At time of writing, not in django-storages docs, but was implemented in:
+# https://github.com/jschneier/django-storages/pull/1112
+# This very similar PR in django-s3-storage has more info:
+# https://github.com/etianen/django-s3-storage/pull/136
+AWS_S3_USE_THREADS = False
 
 # [PySpacer settings]
 SPACER['AWS_ACCESS_KEY_ID'] = AWS_ACCESS_KEY_ID


### PR DESCRIPTION
Since coralnet 1.9 (well, technically coralnet-system 1.4 where the gunicorn config lives) we've been getting this error up to several times a day: `RuntimeError: cannot schedule new futures after interpreter shutdown`. It happens on various Django views such as:

- annotation_tool: when querying DB for image width
- example_patches_ajax: in the generate_patch_if_doesnt_exist() call
- annotation_area_edit: in the reset_features() call

It's likely due to switching from sync workers to gthread workers in gunicorn. Basically happens in certain conditions when boto S3 calls are used in threads, in Python 3.9+. Related issues in other repos:

- boto/boto3 issue 3113
- boto/boto3 issue 3221
- boto/s3transfer issue 197
- python/cpython issue 86813
- etianen/django-s3-storage PR 136
- jschneier/django-storages issue 1110

I can't say for sure if gunicorn gthread workers are the way to go for us, but in general, allowing *some* form of threading for serving views still seems desirable.

However, the main workaround for the above error is apparently to not use threading for S3 calls. There is a django-storages setting `AWS_S3_USE_THREADS` to do just that, so I've toggled it to False in this PR.