### PR TITLE
Deploy: handle UnreadablePostError in addition to ParseError

### DIFF
--- a/project/vision_backend_api/tests/utils.py
+++ b/project/vision_backend_api/tests/utils.py
@@ -6,6 +6,7 @@ from unittest import mock
 from django.conf import settings
 from django.test import override_settings
 from django.urls import reverse
+from rest_framework import status
 
 from api_core.tests.utils import BaseAPITest
 from images.model_utils import PointGen
@@ -62,6 +63,15 @@ class DeployBaseTest(BaseAPITest, metaclass=ABCMeta):
             # but doesn't hurt for other requests either.
             content_type='application/vnd.api+json',
         )
+
+    def assert_expected_400_error(self, response, error_dict):
+        self.assertEqual(
+            response.status_code, status.HTTP_400_BAD_REQUEST,
+            "Should get 400")
+        self.assertDictEqual(
+            response.json(),
+            dict(errors=[error_dict]),
+            "Response JSON should be as expected")
 
     @classmethod
     def train_classifier(cls):

--- a/project/vision_backend_api/views.py
+++ b/project/vision_backend_api/views.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.http import Http404
+from django.http import Http404, UnreadablePostError
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from rest_framework.exceptions import ParseError
@@ -42,7 +42,7 @@ class Deploy(APIView):
         # Check for invalid JSON.
         try:
             request.data
-        except ParseError as e:
+        except (ParseError, UnreadablePostError) as e:
             return Response(
                 dict(errors=[dict(detail=str(e))]),
                 status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
To fix the `UnreadablePostError - [Errno 104] Connection reset by peer` errors that started popping up recently (since December) in the deploy API view. Seems to correspond to a client canceling a deploy request before it goes through. Honestly not sure what change caused this to start happening, maybe one of the numerous package updates from coralnet 1.7. In any case, seems straightforward enough to handle.