### PR TITLE
Don't use gthread for gunicorn anymore (go back to sync workers)

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -5,4 +5,4 @@
 # WSGI HTTP server - The layer above Django, and below the overall web
 # server (e.g. nginx)
 # Changelog: http://docs.gunicorn.org/en/stable/news.html
-gunicorn[gthread]>=20.1.0,<20.2
+gunicorn>=20.1.0,<20.2


### PR DESCRIPTION
Reverting PR #526 basically. The more I thought about it, gthread workers probably don't make sense for us since our processes aren't smart enough to yield control when waiting for I/O things. So at the least it doesn't seem to help. And anecdotally, haven't seen any service improvement from using gthread workers and there's a decent chance it actually made things worse.