### PR TITLE
Define a view-scoped cache in memory, and have label_details use it

### DIFF
--- a/project/config/settings.py
+++ b/project/config/settings.py
@@ -875,6 +875,8 @@ MIDDLEWARE = [
     # each request to understand usage patterns. (ID, not username, to keep
     # things relatively anonymous)
     'lib.middleware.ViewLoggingMiddleware',
+    # Provide a cache which persists for the duration of the view.
+    'lib.middleware.ViewScopedCacheMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
 
     # django-reversion

--- a/project/labels/models.py
+++ b/project/labels/models.py
@@ -215,6 +215,7 @@ cacheable_label_details = CacheableValue(
     cache_update_interval=60*60*24*7,
     cache_timeout_interval=60*60*24*30,
     on_demand_computation_ok=False,
+    use_view_scoped_cache=True,
 )
 
 

--- a/project/lib/middleware.py
+++ b/project/lib/middleware.py
@@ -5,7 +5,24 @@ import uuid
 from django.http import HttpRequest, HttpResponse
 from django.urls import resolve
 
+from .utils import view_scoped_cache
+
 view_logger = getLogger('coralnet_views')
+
+
+class ViewScopedCacheMiddleware:
+    """
+    Provide a cache (key-value store) which persists until the
+    end of the view.
+    """
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        token = view_scoped_cache.set(dict())
+        response = self.get_response(request)
+        view_scoped_cache.reset(token)
+        return response
 
 
 class ViewLoggingMiddleware:

--- a/project/lib/utils.py
+++ b/project/lib/utils.py
@@ -10,7 +10,7 @@ import urllib.parse
 from django.core.cache import cache
 from django.core.paginator import Paginator, EmptyPage, InvalidPage
 
-view_scoped_cache = ContextVar('view_scoped_cache')
+view_scoped_cache = ContextVar('view_scoped_cache', default=None)
 
 
 class CacheableValue:
@@ -59,6 +59,9 @@ class CacheableValue:
             return
 
         view_scoped_cache_dict = view_scoped_cache.get()
+        if view_scoped_cache_dict is None:
+            return
+
         view_scoped_cache_dict[self.cache_key] = value
         view_scoped_cache.set(view_scoped_cache_dict)
 
@@ -76,8 +79,9 @@ class CacheableValue:
         value = None
         if self.use_view_scoped_cache:
             view_scoped_cache_dict = view_scoped_cache.get()
-            # Try the view scoped cache
-            value = view_scoped_cache_dict.get(self.cache_key)
+            if view_scoped_cache_dict is not None:
+                # Try the view scoped cache
+                value = view_scoped_cache_dict.get(self.cache_key)
 
         if value is None:
             # Try the Django cache


### PR DESCRIPTION
Turns out that fetching from the disk-based cache can be a bottleneck if we have to fetch the same large structure 16,000 times in a row.

That is what the label-list view currently does. It fetches the label-details structure twice per label (and there are 8000+ labels in production). For example, the code for getting any label's popularity (to show the colored bar on the label list) involves fetches the label-details structure from the disk-based cache. Those fetches apparently add up to incur 10-20 minutes of load time. It's still better that the popularities are cached at all, so we don't have to compute the popularities for every label on every page load, but it's still much slower than desired.

There were multiple ways of fixing this, but I opted to define another layer of caching: a "view-scoped cache" which is in-memory (thus, faster than the disk-based Django cache), created at the start of a web request, and cleared after handling the request. With this setup, the disk-based Django cache saves us from computing the popularities very often, and the view-scoped in-memory cache saves us from having to fetch the label details from disk more than once per view.

This might raise the question of why we don't use a single memory cache (Redis, Memcached) to try to get the best of both worlds. That might end up being a route I take later if there are more caching pains. But for now, I still find that a disk-based cache smooths things out on the testing, development, and maintenance side; for example, cached values that take a while to generate don't have to be re-generated when the server's restarted. I was also thinking that the view-scoped property of this new cache can be quite useful in other situations, such as caching the results of database queries.