### PR TITLE
Add a bulk version of reset_features()

### DIFF
--- a/project/vision_backend/management/commands/vb_reset_features.py
+++ b/project/vision_backend/management/commands/vb_reset_features.py
@@ -1,7 +1,7 @@
 from django.core.management.base import BaseCommand
 
 from images.models import Image, Source
-from ...utils import reset_features
+from ...utils import reset_features, reset_features_bulk
 
 
 class Command(BaseCommand):
@@ -29,8 +29,7 @@ class Command(BaseCommand):
                 self.stdout.write(
                     f"Initiating feature resets for source"
                     f" {source_id} \"{source}\" ({images.count()} image(s))...")
-                for image in images:
-                    reset_features(image)
+                reset_features_bulk(images)
         else:
             # image_ids
             images = Image.objects.filter(pk__in=options['ids'])

--- a/project/vision_backend/tasks.py
+++ b/project/vision_backend/tasks.py
@@ -37,7 +37,7 @@ from .common import CLASSIFIER_MAPPINGS
 from .exceptions import RowColumnMismatchError
 from .models import Classifier, Score
 from .queues import get_queue_class
-from .utils import get_extractor, reset_features, schedule_source_check
+from .utils import get_extractor, reset_features_bulk, schedule_source_check
 
 logger = getLogger(__name__)
 
@@ -316,8 +316,7 @@ def submit_classifier(source_id, job_id):
     without_feature_rowcols = images.filter(features__has_rowcols=False)
     if without_feature_rowcols.exists():
         count = without_feature_rowcols.count()
-        for image in without_feature_rowcols:
-            reset_features(image)
+        reset_features_bulk(without_feature_rowcols)
         raise JobError(
             f"This source has {count} feature vector(s) without"
             f" rows/columns, and this is no longer accepted for training."
@@ -587,8 +586,7 @@ def reset_backend_for_source(source_id):
         'reset_classifiers_for_source', source_id,
         source_id=source_id)
 
-    for image in Image.objects.filter(source_id=source_id):
-        reset_features(image)
+    reset_features_bulk(Image.objects.filter(source_id=source_id))
 
 
 @job_runner()


### PR DESCRIPTION
The `reset_backend_for_source()` task was taking roughly 1 hour per 5000 images because of this code:

```python
for image in Image.objects.filter(source_id=source_id):
    reset_features(image)
```

Which runs this slow code for each image:

```python
image.refresh_from_db()

features = image.features
features.extracted = False
features.save()
```

The `submit_classifier()` task could also take a similarly long time with the recently-added case that replaces legacy features (PR #525).

In either case, this allows a huey task to actively run for potentially hours, which hogs the task queue and might necessitate a force-stop during server maintenance.

This PR greatly speeds up these situations by using a bulk-operation version of `reset_features()`. On the staging server, reset_backend_for_source() now takes less than 1 minute (instead of 1 hour) on a 5000-image source.
