### PR TITLE
Update to pyspacer 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ For info about the semantic versioning used here, see `docs/versions.rst`.
 ## 1.12 (WIP)
 
 - New package to install: django-huey>=1.1.2,<1.2
+- Updates to required packages:
+  - pyspacer 0.8.0 -> 0.9.0
+  - Pillow 10.2.0 -> 10.3.0
+  - django-markdownx `==4.0.2` -> `>=4.0.7,<4.1`
 - New migrations to run for `jobs`.
 
 ## [1.11.1](https://github.com/coralnet/coralnet/tree/1.11.1)

--- a/project/config/settings.py
+++ b/project/config/settings.py
@@ -344,6 +344,19 @@ NBR_TRAINING_EPOCHS = 10
 # Batch size for pyspacer's batching of training-annotations.
 TRAINING_BATCH_LABEL_COUNT = 5000
 
+# Feature caching can greatly speed up pyspacer training, but might make
+# training fail if the amount to cache approaches the available storage space.
+#
+# Since we no longer accept legacy-format (pre-2021) features for training,
+# we can expect feature vectors to be about 5.5 KB per point. (Legacy ones
+# were about 8x bigger.)
+# As of 2024/04, CoralNet's AWS Batch instances use 30 GB storage volumes.
+# That should leave at least 15 GB for feature caching.
+# 15 GB divided by 5.5 KB = a little over 2.5 million points. So we'll use
+# that as the default limit for allowing feature caching in training.
+FEATURE_CACHING_ANNOTATION_LIMIT = env(
+    'FEATURE_CACHING_ANNOTATION_LIMIT', default=2500000)
+
 # Spacer job hash to identify this server instance's jobs in the AWS Batch
 # dashboard.
 SPACER_JOB_HASH = env('SPACER_JOB_HASH', default='default_hash')

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -176,4 +176,4 @@ numpy==1.24.1
 # Machine-learning backend behind coralnet
 # This can be installed from a local directory (not just PyPI), as long as
 # the local copy's setup.py matches this version number.
-pyspacer==0.8.0
+pyspacer==0.9.0


### PR DESCRIPTION
This version introduces a feature-caching option for training, which gives training roughly a 6x speedup. However, we disable the option when the dataset's greater than a certain number of annotations, since that could make the training instance run out of storage space.

This version also introduces more flexibility when having pyspacer do the train/ref/val split on the training data. But CoralNet still does its own train/ref/val split logic for now, just because it's not urgent to change that. It would be preferable to leave the logic to pyspacer though, since the way pyspacer 0.9.0 does it should have better properties, so that's future work.