### PR TITLE
Spacer result collection: truncate errors before emailing/logging

### DIFF
--- a/project/config/settings.py
+++ b/project/config/settings.py
@@ -211,6 +211,20 @@ elif SETTINGS_BASE in [Bases.DEV_LOCAL, Bases.DEV_S3]:
     EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 # Else (production), use the default email backend (smtp).
 
+# Any outgoing email with an element that could get very large (in bytes)
+# should truncate/limit that element according to this setting.
+# The resulting total size of the email (incorporating other elements, e.g.
+# both subject and body) may go above this limit, hence it's a 'soft' limit.
+#
+# We go for about 100 KB here. We consider the 'hard' limit to be around 10 MB,
+# which is where email software may start encountering issues. For example,
+# the default max outgoing message size in Postfix seems to be about 10 MB.
+# However, CoralNet only anticipates sending emails of pure text, and 10 MB
+# generally has images and attachment in mind. So, anything greater than 100 KB
+# is most likely a stack trace or data structure which isn't useful to print in
+# its entirety.
+EMAIL_SIZE_SOFT_LIMIT = 100000
+
 
 #
 # Database related

--- a/project/lib/tests/utils.py
+++ b/project/lib/tests/utils.py
@@ -1083,6 +1083,7 @@ class EmailAssertionsMixin(TestCase):
         self,
         subject: str = None,
         body_contents: list[str] = None,
+        body_not_contains: list[str] = None,
         to: list[str] = None,
         cc: list[str] = None,
         bcc: list[str] = None,
@@ -1110,6 +1111,15 @@ class EmailAssertionsMixin(TestCase):
                 body_content,
                 email.body,
                 "Email body should have the expected content")
+
+        body_not_contains = body_not_contains or []
+        # Assert that each element of body_not_contains is NOT present in the
+        # body.
+        for body_content in body_not_contains:
+            self.assertNotIn(
+                body_content,
+                email.body,
+                "Email body should not have this content")
 
         if to is not None:
             self.assertSetEqual(

--- a/project/vision_backend/task_helpers.py
+++ b/project/vision_backend/task_helpers.py
@@ -203,9 +203,17 @@ class SpacerResultHandler(ABC):
 
             if error_class not in cls.non_priority_error_classes:
                 # Priority error; treat like an internal server error.
+
+                job_res_repr = repr(job_res)
+                if len(job_res_repr) > settings.EMAIL_SIZE_SOFT_LIMIT:
+                    job_res_repr = (
+                        job_res_repr[:settings.EMAIL_SIZE_SOFT_LIMIT]
+                        + " ...(truncated)"
+                    )
+
                 mail_admins(
                     f"Spacer job failed: {cls.job_name}",
-                    repr(job_res),
+                    job_res_repr,
                 )
 
                 error_class_name = error_class.split('.')[-1]
@@ -215,7 +223,7 @@ class SpacerResultHandler(ABC):
                     html=error_html,
                     path=f"Spacer - {cls.job_name}",
                     info=error_info,
-                    data=repr(job_res),
+                    data=job_res_repr,
                 )
                 error_log.save()
 


### PR DESCRIPTION
When a priority error is found during spacer result collection, truncate the error repr before adding it to the admin-email and errorlog.

In particular, the error repr of a failed training run can be VERY large, containing every single element of a TrainingTaskLabels structure. There were instances where this went into an admin-email, and caused an SMTPSenderRefused error with "Message size exceeds fixed limit". And the main consequence of that was, since the coralnet process crashed during spacer result collection, the Job was never marked as completed and was stuck at in-progress, needing manual intervention to clean it up.

So the error-repr truncation in this PR is meant to prevent that situation. Another thing I could have done would be changing the error repr, to strike a better balance between having maximum information vs. not having problematic length. That would mean changing `__repr__()` of `DataClass` or its subclass(es) in pyspacer. I think that's worth doing at some point, but I thought it was best for coralnet to be defensive in this part of the code either way. So here I'm taking care of the coralnet side of things.