### PR TITLE
Django 4.2 (from 4.1) + package updates + S3 test fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For info about the semantic versioning used here, see `docs/versions.rst`.
 ## 1.14 (WIP)
 
 - Updates to required packages:
+  - django-environ 0.10.0 -> `@git+https://github.com/joke2k/django-environ.git@a1113e41f134d3a5b2b6f98c81539f07da2269a7`
   - django-guardian 2.4.0 -> `@git+https://github.com/StephenChan/django-guardian.git@django5.0`
   - django-registration 3.3 -> 3.4
   - djangorestframework 3.14.0 -> 3.15.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ For info about the semantic versioning used here, see `docs/versions.rst`.
 ## 1.14 (WIP)
 
 - Updates to required packages:
+  - django-registration 3.3 -> 3.4
+  - djangorestframework 3.14.0 -> 3.15.1
+  - django-reversion 5.0.4 -> 5.0.12
   - django-storages 1.13.2 -> django-storages\[s3\] 1.14.4
+  - pytz can now be uninstalled, since djangorestframework no longer depends on it.
 
 ## [1.13.1](https://github.com/coralnet/coralnet/tree/1.13.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ For info about the semantic versioning used here, see `docs/versions.rst`.
 
 - Updates to required packages:
   - django-environ 0.10.0 -> `@git+https://github.com/joke2k/django-environ.git@a1113e41f134d3a5b2b6f98c81539f07da2269a7`
-  - django-guardian 2.4.0 -> `@git+https://github.com/StephenChan/django-guardian.git@django5.0`
+  - django-guardian 2.4.0 -> `@git+https://github.com/StephenChan/django-guardian.git@2.4.0+coralnet`
   - django-registration 3.3 -> 3.4
   - djangorestframework 3.14.0 -> 3.15.1
   - django-reversion 5.0.4 -> 5.0.12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For info about the semantic versioning used here, see `docs/versions.rst`.
 ## 1.14 (WIP)
 
 - Updates to required packages:
+  - Django `>=4.1.9,<4.2` -> `>=4.2.16,<5.0`
   - django-environ 0.10.0 -> `@git+https://github.com/coralnet/django-environ.git@0.11.2+coralnet`
   - django-guardian 2.4.0 -> `@git+https://github.com/StephenChan/django-guardian.git@2.4.0+coralnet`
   - django-registration 3.3 -> 3.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ For info about the semantic versioning used here, see `docs/versions.rst`.
 "Production:" dates under each version indicate when the production server was updated to that version.
 
 
+## 1.14 (WIP)
+
+- Updates to required packages:
+  - django-storages 1.13.2 -> 1.14.4
+
 ## [1.13.1](https://github.com/coralnet/coralnet/tree/1.13.1)
 
 Production: 2024-06-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ For info about the semantic versioning used here, see `docs/versions.rst`.
 ## 1.14 (WIP)
 
 - Updates to required packages:
-  - django-environ 0.10.0 -> `@git+https://github.com/joke2k/django-environ.git@a1113e41f134d3a5b2b6f98c81539f07da2269a7`
+  - django-environ 0.10.0 -> `@git+https://github.com/coralnet/django-environ.git@0.11.2+coralnet`
   - django-guardian 2.4.0 -> `@git+https://github.com/StephenChan/django-guardian.git@2.4.0+coralnet`
   - django-registration 3.3 -> 3.4
   - djangorestframework 3.14.0 -> 3.15.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For info about the semantic versioning used here, see `docs/versions.rst`.
 ## 1.14 (WIP)
 
 - Updates to required packages:
+  - django-guardian 2.4.0 -> `@git+https://github.com/StephenChan/django-guardian.git@django5.0`
   - django-registration 3.3 -> 3.4
   - djangorestframework 3.14.0 -> 3.15.1
   - django-reversion 5.0.4 -> 5.0.12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ For info about the semantic versioning used here, see `docs/versions.rst`.
   - djangorestframework 3.14.0 -> 3.15.1
   - django-reversion 5.0.4 -> 5.0.12
   - django-storages 1.13.2 -> django-storages\[s3\] 1.14.4
+  - easy-thumbnails `@git+https://github.com/StephenChan/easy-thumbnails.git@master` -> `@git+https://github.com/StephenChan/easy-thumbnails.git@2.9+coralnet`
   - pytz can now be uninstalled, since djangorestframework no longer depends on it.
 
 ## [1.13.1](https://github.com/coralnet/coralnet/tree/1.13.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ For info about the semantic versioning used here, see `docs/versions.rst`.
 ## 1.14 (WIP)
 
 - Updates to required packages:
-  - django-storages 1.13.2 -> 1.14.4
+  - django-storages 1.13.2 -> django-storages\[s3\] 1.14.4
 
 ## [1.13.1](https://github.com/coralnet/coralnet/tree/1.13.1)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,12 @@ For info about the semantic versioning used here, see `docs/versions.rst`.
   - django-environ 0.10.0 -> `@git+https://github.com/coralnet/django-environ.git@0.11.2+coralnet`
   - django-guardian 2.4.0 -> `@git+https://github.com/StephenChan/django-guardian.git@2.4.0+coralnet`
   - django-registration 3.3 -> 3.4
-  - djangorestframework 3.14.0 -> 3.15.1
-  - django-reversion 5.0.4 -> 5.0.12
+  - djangorestframework 3.14.0 -> 3.15.2
+  - django-reversion 5.0.4 -> 5.1.0
   - django-storages 1.13.2 -> django-storages\[s3\] 1.14.4
   - easy-thumbnails `@git+https://github.com/StephenChan/easy-thumbnails.git@master` -> `@git+https://github.com/StephenChan/easy-thumbnails.git@2.9+coralnet`
+  - tqdm 4.65.0 -> 4.66.5
+  - gunicorn `>=20.1.0,<20.2` -> 23.0.0 (for production)
   - pytz can now be uninstalled, since djangorestframework no longer depends on it.
 
 ## [1.13.1](https://github.com/coralnet/coralnet/tree/1.13.1)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -115,7 +115,6 @@ Certain file-creation parts of the project code may trigger an error such as ``N
 
 - ``<SITE_DIR>/log``
 - ``<SITE_DIR>/tmp``
-- ``<MEDIA_ROOT>/unittests`` (local-machine storage only)
 
 
 Running the unit tests

--- a/project/accounts/hashers.py
+++ b/project/accounts/hashers.py
@@ -1,5 +1,7 @@
+import hashlib
+
 from django.contrib.auth.hashers import (
-    PBKDF2PasswordHasher, SHA1PasswordHasher)
+    BasePasswordHasher, PBKDF2PasswordHasher)
 
 
 class PBKDF2WrappedSHA1PasswordHasher(PBKDF2PasswordHasher):
@@ -16,3 +18,17 @@ class PBKDF2WrappedSHA1PasswordHasher(PBKDF2PasswordHasher):
         _, _, sha1_hash = \
             SHA1PasswordHasher().encode(password, salt).split('$', 2)
         return self.encode_sha1_hash(sha1_hash, salt, iterations)
+
+
+class SHA1PasswordHasher(BasePasswordHasher):
+    """
+    From older versions of Django. This is used by the wrapped password
+    hasher. This shouldn't be used directly (unwrapped) because the algorithm
+    is not secure enough.
+    """
+    algorithm = 'sha1'
+
+    def encode(self, password, salt):
+        self._check_encode_args(password, salt)
+        hash = hashlib.sha1((salt + password).encode()).hexdigest()
+        return '%s$%s$%s' % (self.algorithm, salt, hash)

--- a/project/accounts/tests/test_signin.py
+++ b/project/accounts/tests/test_signin.py
@@ -1,9 +1,9 @@
 from django.contrib.auth import get_user_model
-from django.contrib.auth.hashers import (
-    make_password, SHA1PasswordHasher)
+from django.contrib.auth.hashers import make_password
 from django.urls import reverse
 
 from lib.tests.utils import BasePermissionTest, BrowserTest, ClientTest
+from ..hashers import SHA1PasswordHasher
 from .utils import BaseAccountsTest
 
 User = get_user_model()

--- a/project/async_media/tests/tests.py
+++ b/project/async_media/tests/tests.py
@@ -5,7 +5,7 @@ import warnings
 
 from bs4 import BeautifulSoup
 from django.conf import settings
-from django.core.files.storage import get_storage_class
+from django.core.files.storage import DefaultStorage
 from django.test import override_settings
 from django.urls import reverse
 from easy_thumbnails.files import get_thumbnailer
@@ -282,7 +282,7 @@ class ThumbnailsTest(AsyncMediaTest):
         img = self.upload_image(self.user, self.source)
 
         # Delete the original image file
-        storage = get_storage_class()()
+        storage = DefaultStorage()
         storage.delete(img.original_file.name)
 
         batch_key, media_keys = self.load_browse_and_get_media_keys()[0]

--- a/project/async_media/tests/tests.py
+++ b/project/async_media/tests/tests.py
@@ -5,7 +5,7 @@ import warnings
 
 from bs4 import BeautifulSoup
 from django.conf import settings
-from django.core.files.storage import DefaultStorage
+from django.core.files.storage import default_storage
 from django.test import override_settings
 from django.urls import reverse
 from easy_thumbnails.files import get_thumbnailer
@@ -282,8 +282,7 @@ class ThumbnailsTest(AsyncMediaTest):
         img = self.upload_image(self.user, self.source)
 
         # Delete the original image file
-        storage = DefaultStorage()
-        storage.delete(img.original_file.name)
+        default_storage.delete(img.original_file.name)
 
         batch_key, media_keys = self.load_browse_and_get_media_keys()[0]
 

--- a/project/async_media/tests/tests.py
+++ b/project/async_media/tests/tests.py
@@ -62,7 +62,8 @@ class AsyncMediaTest(ClientTest):
 
 @skipIf(
     os.name == 'nt'
-    and settings.DEFAULT_FILE_STORAGE == 'lib.storage_backends.MediaStorageS3',
+    and settings.STORAGES['default']['BACKEND']
+        == 'lib.storage_backends.MediaStorageS3',
     "Fetching existing thumbnails doesn't work with Windows + S3, because"
     " easy-thumbnails uses os.path for storage path separators")
 class ThumbnailsTest(AsyncMediaTest):

--- a/project/async_media/utils.py
+++ b/project/async_media/utils.py
@@ -2,7 +2,7 @@ import abc
 import uuid
 
 from django.conf import settings
-from django.core.files.storage import DefaultStorage
+from django.core.files.storage import default_storage
 from django.templatetags.static import static as to_static_path
 from easy_thumbnails.files import get_thumbnailer
 
@@ -121,10 +121,9 @@ class AsyncPatch(AsyncMediaItem):
         return (self.point_id,)
 
     def get_url(self):
-        storage = DefaultStorage()
         # Check if patch exists for the point.
         patch_relative_path = get_patch_path(self.point_id)
-        if storage.exists(patch_relative_path):
+        if default_storage.exists(patch_relative_path):
             return get_patch_url(self.point_id)
         else:
             return None

--- a/project/async_media/utils.py
+++ b/project/async_media/utils.py
@@ -2,7 +2,7 @@ import abc
 import uuid
 
 from django.conf import settings
-from django.core.files.storage import get_storage_class
+from django.core.files.storage import DefaultStorage
 from django.templatetags.static import static as to_static_path
 from easy_thumbnails.files import get_thumbnailer
 
@@ -121,8 +121,7 @@ class AsyncPatch(AsyncMediaItem):
         return (self.point_id,)
 
     def get_url(self):
-        # Get the storage class, then get an instance of it.
-        storage = get_storage_class()()
+        storage = DefaultStorage()
         # Check if patch exists for the point.
         patch_relative_path = get_patch_path(self.point_id)
         if storage.exists(patch_relative_path):

--- a/project/blog/models.py
+++ b/project/blog/models.py
@@ -56,8 +56,20 @@ class BlogPost(models.Model):
         # Time to publish?
         if not self.published_timestamp and self.is_published:
             self.published_timestamp = timezone.now()
-        elif not self.is_published:
+            updating_timestamp = True
+        elif self.published_timestamp and not self.is_published:
             self.published_timestamp = None
+            updating_timestamp = True
+        else:
+            updating_timestamp = False
+
+        if updating_timestamp:
+            # Custom save() methods which update field values should add those
+            # field names to the update_fields kwarg.
+            # https://docs.djangoproject.com/en/4.2/topics/db/models/#overriding-predefined-model-methods
+            if (update_fields := kwargs.get('update_fields')) is not None:
+                kwargs['update_fields'] = (
+                    {'published_timestamp'}.union(update_fields))
 
         super().save(*args, **kwargs)
 

--- a/project/config/settings.py
+++ b/project/config/settings.py
@@ -626,6 +626,21 @@ STORAGES = {
     'easy_thumbnails': _STORAGES_DEFAULT,
 }
 
+if (
+    SPACER_QUEUE_CHOICE == 'vision_backend.queues.BatchQueue'
+    and
+    STORAGES['default']['BACKEND'] == 'lib.storage_backends.MediaStorageLocal'
+    and
+    not _TESTING
+):
+    # We only raise this in non-test environments, because some tests
+    # are able to use mocks to test BatchQueue while sticking with
+    # local storage.
+    raise ImproperlyConfigured(
+        "Can not use Remote queue with local storage."
+        " Please use S3 storage."
+    )
+
 
 #
 # Authentication, security, web server

--- a/project/config/settings.py
+++ b/project/config/settings.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 import sys
 
+import boto3.s3.transfer
 # In many cases it's dangerous to import from Django directly into a settings
 # module, but ImproperlyConfigured is fine.
 from django.core.exceptions import ImproperlyConfigured
@@ -452,14 +453,17 @@ AWS_BATCH_REGION = env('AWS_BATCH_REGION', default='us-west-2')
 # http://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html
 AWS_ACCESS_KEY_ID = env('AWS_ACCESS_KEY_ID', default=None)
 AWS_SECRET_ACCESS_KEY = env('AWS_SECRET_ACCESS_KEY', default=None)
-# Added in 1.13; disables using threads for S3 requests, preventing errors
-# such as
-# `RuntimeError: cannot schedule new futures after interpreter shutdown`
-# At time of writing, not in django-storages docs, but was implemented in:
-# https://github.com/jschneier/django-storages/pull/1112
-# This very similar PR in django-s3-storage has more info:
-# https://github.com/etianen/django-s3-storage/pull/136
-AWS_S3_USE_THREADS = False
+AWS_S3_TRANSFER_CONFIG = boto3.s3.transfer.TransferConfig(
+    # Disables using threads for S3 requests, preventing errors such as
+    # `RuntimeError: cannot schedule new futures after interpreter shutdown`
+    # More info on how this relates to the error:
+    # https://github.com/jschneier/django-storages/pull/1112
+    # https://github.com/etianen/django-s3-storage/pull/136
+    #
+    # Formerly set by the django-storages setting AWS_S3_USE_THREADS
+    # (deprecated starting from django-storages 1.14).
+    use_threads=False,
+)
 
 # [PySpacer settings]
 SPACER['AWS_ACCESS_KEY_ID'] = AWS_ACCESS_KEY_ID

--- a/project/events/models.py
+++ b/project/events/models.py
@@ -41,8 +41,14 @@ class Event(models.Model):
     required_id_fields: list[str] = []
 
     def save(self, *args, **kwargs):
-        if self.type_for_subclass:
+        if self.type_for_subclass and self.type != self.type_for_subclass:
             self.type = self.type_for_subclass
+
+            # Custom save() methods which update field values should add those
+            # field names to the update_fields kwarg.
+            # https://docs.djangoproject.com/en/4.2/topics/db/models/#overriding-predefined-model-methods
+            if (update_fields := kwargs.get('update_fields')) is not None:
+                kwargs['update_fields'] = {'type'}.union(update_fields)
 
         for field_name in self.required_id_fields:
             if not getattr(self, field_name):

--- a/project/images/management/commands/checkformissingimages.py
+++ b/project/images/management/commands/checkformissingimages.py
@@ -3,7 +3,7 @@ from io import open
 import os
 import posixpath
 from django.conf import settings
-from django.core.files.storage import get_storage_class
+from django.core.files.storage import DefaultStorage
 from django.core.management.base import BaseCommand
 from images.models import Image
 
@@ -14,7 +14,7 @@ class Command(BaseCommand):
             " nonexistent image filepaths")
 
     def handle(self, *args, **options):
-        storage = get_storage_class()()
+        storage = DefaultStorage()
 
         images_relative_dir = posixpath.split(settings.IMAGE_FILE_PATTERN)[0]
 

--- a/project/images/management/commands/checkformissingimages.py
+++ b/project/images/management/commands/checkformissingimages.py
@@ -3,7 +3,7 @@ from io import open
 import os
 import posixpath
 from django.conf import settings
-from django.core.files.storage import DefaultStorage
+from django.core.files.storage import default_storage
 from django.core.management.base import BaseCommand
 from images.models import Image
 
@@ -14,14 +14,12 @@ class Command(BaseCommand):
             " nonexistent image filepaths")
 
     def handle(self, *args, **options):
-        storage = DefaultStorage()
-
         images_relative_dir = posixpath.split(settings.IMAGE_FILE_PATTERN)[0]
 
         self.stdout.write(
             "Reading the image files directory: {dir}. This could take"
             " a while...".format(dir=images_relative_dir))
-        dirnames, filenames = storage.listdir(images_relative_dir)
+        dirnames, filenames = default_storage.listdir(images_relative_dir)
         filenames = set(filenames)
 
         self.stdout.write(

--- a/project/jobs/tests/test_utils.py
+++ b/project/jobs/tests/test_utils.py
@@ -100,7 +100,7 @@ class ScheduleJobTest(BaseTest, EmailAssertionsMixin, ErrorReportTestMixin):
             "Job has been failing repeatedly: name / arg, attempt 5",
             ["Error info:\n\nAn error"],
         )
-        self.assertAlmostEquals(
+        self.assertAlmostEqual(
             datetime.now(timezone.utc) + timedelta(days=3),
             job.scheduled_start_date,
             delta=timedelta(minutes=10),
@@ -128,7 +128,7 @@ class ScheduleJobTest(BaseTest, EmailAssertionsMixin, ErrorReportTestMixin):
             "Job has been failing repeatedly: name / arg, attempt 5",
             ["Error info:\n\nAn error"],
         )
-        self.assertAlmostEquals(
+        self.assertAlmostEqual(
             datetime.now(timezone.utc) + timedelta(days=5),
             job.scheduled_start_date,
             delta=timedelta(minutes=10),
@@ -145,7 +145,7 @@ class ScheduleJobTest(BaseTest, EmailAssertionsMixin, ErrorReportTestMixin):
             # Call again with shorter delay
             schedule_job('name', 'arg', delay=timedelta(days=2))
             job.refresh_from_db()
-            self.assertAlmostEquals(
+            self.assertAlmostEqual(
                 datetime.now(timezone.utc) + timedelta(days=2),
                 job.scheduled_start_date,
                 delta=timedelta(minutes=10),
@@ -161,7 +161,7 @@ class ScheduleJobTest(BaseTest, EmailAssertionsMixin, ErrorReportTestMixin):
         # Call again with shorter delay
         schedule_job('name', 'arg', delay=timedelta(days=2))
         job.refresh_from_db()
-        self.assertAlmostEquals(
+        self.assertAlmostEqual(
             datetime.now(timezone.utc) + timedelta(days=5),
             job.scheduled_start_date,
             delta=timedelta(minutes=10),
@@ -361,7 +361,7 @@ class JobDecoratorTest(BaseTest, ErrorReportTestMixin, EmailAssertionsMixin):
             # Task args
             r";;;\('some_arg',\)"
         )
-        self.assertRegexpMatches(
+        self.assertRegex(
             cm.output[0],
             expected_start_message_regex,
             f"Should log the expected start message")
@@ -376,7 +376,7 @@ class JobDecoratorTest(BaseTest, ErrorReportTestMixin, EmailAssertionsMixin):
             r"full_job_example;"
             r";;;\('some_arg',\)"
         )
-        self.assertRegexpMatches(
+        self.assertRegex(
             cm.output[1],
             expected_end_message_regex,
             f"Should log the expected end message")

--- a/project/lib/apps.py
+++ b/project/lib/apps.py
@@ -1,0 +1,9 @@
+from django.apps import AppConfig
+
+
+class LibConfig(AppConfig):
+    name = 'lib'
+
+    def ready(self):
+        # Implicitly connect signal handlers decorated with @receiver.
+        from .tests import signals

--- a/project/lib/regtest_utils.py
+++ b/project/lib/regtest_utils.py
@@ -10,7 +10,7 @@ from django.contrib.auth import get_user_model
 from django.core.files.base import ContentFile
 from django.test.client import Client
 from django.urls import reverse
-from storages.backends.s3boto3 import S3Boto3Storage
+from storages.backends.s3 import S3Storage
 
 from labels.models import LabelGroup, Label, LabelSet, LocalLabel
 from sources.models import Source
@@ -31,7 +31,7 @@ class VisionBackendRegressionTest(ClientTest):
         self.use_vgg16 = use_vgg16
 
         self.client = Client()
-        self.regtest_storage = S3Boto3Storage(
+        self.regtest_storage = S3Storage(
             bucket_name=settings.REGTEST_BUCKET, location='')
 
         # Get any superuser. We'll assume one exists (if it doesn't, this'll

--- a/project/lib/storage_backends.py
+++ b/project/lib/storage_backends.py
@@ -11,7 +11,7 @@ from spacer.messages import DataLocation
 
 from django.conf import settings
 from django.core.files.storage import DefaultStorage, FileSystemStorage
-from storages.backends.s3boto3 import S3Boto3Storage
+from storages.backends.s3 import S3Storage
 
 from .exceptions import FileStorageUsageError
 
@@ -206,16 +206,16 @@ class StorageManagerLocal(StorageManager):
         shutil.rmtree(dir_to_remove)
 
 
-class MediaStorageS3(S3Boto3Storage):
+class MediaStorageS3(S3Storage):
     """
     S3-bucket storage backend.
     Storage root defaults to the AWS_LOCATION directory.
     """
     def __init__(self, **kwargs):
-        # django-storages's S3Boto3Storage is implemented a bit differently from
+        # django-storages's S3Storage is implemented a bit differently from
         # Django's FileSystemStorage: it initializes the location attribute to
         # the appropriate setting on the class definition level, rather than in
-        # __init__(). This means S3Boto3Storage might not pick up changes to
+        # __init__(). This means S3Storage might not pick up changes to
         # settings, which might occur when unit testing for example.
         #
         # To allow S3 storage to pick up on settings changes, we'll pass a

--- a/project/lib/storage_backends.py
+++ b/project/lib/storage_backends.py
@@ -292,6 +292,9 @@ class MediaStorageLocal(FileSystemStorage):
         """ Returns a spacer DataLocation object. """
         return DataLocation(storage_type='filesystem',
                             key=self.path(key))
+
+
+_s3_root_storage = None
  
 
 def get_s3_root_storage():
@@ -299,10 +302,15 @@ def get_s3_root_storage():
     Returns an S3 storage backend which accepts operations throughout an
     entire bucket, rather than only within a settings-specified directory.
     """
-    # S3 storage's __init__() accepts kwargs to override default attributes.
-    # `location` is the path from the bucket root which will be used as the
-    # storage root. We want to use bucket root as storage root, so we pass ''.
-    return MediaStorageS3(location='')
+    global _s3_root_storage
+
+    if _s3_root_storage is None:
+        # S3 storage's __init__() accepts kwargs to override default
+        # attributes. `location` is the path from the bucket root which will
+        # be used as the storage root. We want to use bucket root as storage
+        # root, so we pass ''.
+        _s3_root_storage = MediaStorageS3(location='')
+    return _s3_root_storage
 
 
 def get_storage_manager():

--- a/project/lib/tests/signals.py
+++ b/project/lib/tests/signals.py
@@ -1,0 +1,24 @@
+from django.core.signals import setting_changed
+from django.dispatch import receiver
+
+
+@receiver(setting_changed)
+def aws_location_changed(*, setting, **kwargs):
+    """
+    Update S3 storage location attributes when AWS_LOCATION is changed.
+    This assumes that all S3 storages specified in STORAGES are using
+    AWS_LOCATION and not their own location kwarg.
+
+    Unlike django.test.signals.storages_changed(), this doesn't have to
+    re-instantiate any storages, which makes a substantial time difference
+    with S3 storage.
+    """
+    from django.core.files.storage import storages
+    from storages.backends.s3 import S3Storage
+
+    if setting == 'AWS_LOCATION':
+        new_location = kwargs['value']
+
+        for alias, storage in storages._storages.items():
+            if isinstance(storage, S3Storage):
+                storage.location = new_location

--- a/project/lib/tests/test_middleware.py
+++ b/project/lib/tests/test_middleware.py
@@ -35,7 +35,7 @@ class ViewLoggingMiddlewareTest(ClientTest):
             r"index;"
             r";GET;Guest;/"
         )
-        self.assertRegexpMatches(
+        self.assertRegex(
             cm.output[0],
             expected_start_message_regex,
             f"Should log the expected start message")
@@ -51,7 +51,7 @@ class ViewLoggingMiddlewareTest(ClientTest):
             # Status code; method; user ID or 'Guest'; request path
             r"200;GET;Guest;/"
         )
-        self.assertRegexpMatches(
+        self.assertRegex(
             cm.output[1],
             expected_end_message_regex,
             f"Should log the expected end message")

--- a/project/lib/tests/test_storage.py
+++ b/project/lib/tests/test_storage.py
@@ -7,7 +7,7 @@ import urllib.request
 
 from django.conf import settings
 from django.core.cache import cache
-from django.core.files.storage import DefaultStorage
+from django.core.files.storage import default_storage
 from django.test import override_settings
 from easy_thumbnails.files import get_thumbnailer
 # `from easy_thumbnails.storage import <something>` seems to have potential
@@ -35,12 +35,11 @@ class TestSettingsStorageTest(BaseTest):
     def setUpTestData(cls):
         super().setUpTestData()
 
-        cls.storage = DefaultStorage()
         cls.thumbnail_storage = \
             easy_thumbnails.storage.thumbnail_default_storage
 
-        cls.storage.save('1.png', sample_image_as_file('1.png'))
-        cls.storage.save('2.png', sample_image_as_file('2.png'))
+        default_storage.save('1.png', sample_image_as_file('1.png'))
+        default_storage.save('2.png', sample_image_as_file('2.png'))
 
         cls.generate_thumbnail('1.png')
         cls.generate_thumbnail('2.png')
@@ -53,8 +52,8 @@ class TestSettingsStorageTest(BaseTest):
     def test_storage_locations(self):
         # Should be using a temporary directory.
         self.assertTrue(
-            'tmp' in self.storage.location
-            or 'temp' in self.storage.location)
+            'tmp' in default_storage.location
+            or 'temp' in default_storage.location)
 
         # Same for easy-thumbnails storage.
         self.assertTrue(
@@ -63,26 +62,26 @@ class TestSettingsStorageTest(BaseTest):
 
         # And they should be the same. Same location + both local or both S3.
         self.assertEqual(
-            self.storage.location, self.thumbnail_storage.location)
+            default_storage.location, self.thumbnail_storage.location)
         self.assertEqual(
-            self.storage.__class__, self.thumbnail_storage.__class__)
+            default_storage.__class__, self.thumbnail_storage.__class__)
 
     def test_add_file(self):
-        self.storage.save('3.png', sample_image_as_file('3.png'))
+        default_storage.save('3.png', sample_image_as_file('3.png'))
 
         # Files added from setUpTestData(), plus the file added just now,
         # should all be present.
         # And if test_delete_file() ran before this, that shouldn't affect
         # the result.
-        self.assertTrue(self.storage.exists('1.png'))
-        self.assertTrue(self.storage.exists('2.png'))
-        self.assertTrue(self.storage.exists('3.png'))
+        self.assertTrue(default_storage.exists('1.png'))
+        self.assertTrue(default_storage.exists('2.png'))
+        self.assertTrue(default_storage.exists('3.png'))
 
     def test_add_file_check_thumbnail(self):
         """
         Thumbnail-storage equivalent of test_add_file().
         """
-        self.storage.save('3.png', sample_image_as_file('3.png'))
+        default_storage.save('3.png', sample_image_as_file('3.png'))
         self.generate_thumbnail('3.png')
 
         self.assertTrue(
@@ -93,15 +92,15 @@ class TestSettingsStorageTest(BaseTest):
             self.thumbnail_storage.exists('3.png.40x40_q85.jpg'))
 
     def test_delete_file(self):
-        self.storage.delete('1.png')
+        default_storage.delete('1.png')
 
         # Files added from setUpTestData(), except the file deleted just now,
         # should be present.
         # And if test_add_file() ran before this, that shouldn't affect
         # the result.
-        self.assertFalse(self.storage.exists('1.png'))
-        self.assertTrue(self.storage.exists('2.png'))
-        self.assertFalse(self.storage.exists('3.png'))
+        self.assertFalse(default_storage.exists('1.png'))
+        self.assertTrue(default_storage.exists('2.png'))
+        self.assertFalse(default_storage.exists('3.png'))
 
     def test_delete_thumbnail(self):
         """

--- a/project/lib/tests/test_storage.py
+++ b/project/lib/tests/test_storage.py
@@ -7,10 +7,62 @@ import urllib.request
 
 from django.conf import settings
 from django.core.cache import cache
+from django.core.files.storage import DefaultStorage
 from django.test import override_settings
 
+from jobs.models import Job
+from jobs.utils import full_job
+from ..middleware import ViewScopedCacheMiddleware
 from ..storage_backends import StorageManagerLocal
-from .utils import BaseTest, ClientTest
+from ..utils import (
+    CacheableValue,
+    context_scoped_cache,
+    scoped_cache_context_var,
+)
+from .utils import BaseTest, ClientTest, sample_image_as_file
+
+
+class TestSettingsStorageTest(BaseTest):
+    """
+    Test the file storage settings logic used during unit tests.
+    """
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        storage = DefaultStorage()
+        storage.save('1.png', sample_image_as_file('1.png'))
+        storage.save('2.png', sample_image_as_file('2.png'))
+
+    def test_storage_location_is_temporary(self):
+        storage = DefaultStorage()
+
+        # Should be using a temporary directory.
+        self.assertTrue('tmp' in storage.location or 'temp' in storage.location)
+
+    def test_add_file(self):
+        storage = DefaultStorage()
+        storage.save('3.png', sample_image_as_file('3.png'))
+
+        # Files added from setUpTestData(), plus the file added just now,
+        # should all be present.
+        # And if test_delete_file() ran before this, that shouldn't affect
+        # the result.
+        self.assertTrue(storage.exists('1.png'))
+        self.assertTrue(storage.exists('2.png'))
+        self.assertTrue(storage.exists('3.png'))
+
+    def test_delete_file(self):
+        storage = DefaultStorage()
+        storage.delete('1.png')
+
+        # Files added from setUpTestData(), except the file deleted just now,
+        # should be present.
+        # And if test_add_file() ran before this, that shouldn't affect
+        # the result.
+        self.assertFalse(storage.exists('1.png'))
+        self.assertTrue(storage.exists('2.png'))
+        self.assertFalse(storage.exists('3.png'))
 
 
 @skipIf(
@@ -153,3 +205,122 @@ class CacheTest(BaseTest):
             )
 
         storage_manager.remove_temp_dir(cache_dir)
+
+
+class ContextScopedCacheTest(ClientTest):
+
+    def test_scope_not_active(self):
+        self.assertIsNone(
+            scoped_cache_context_var.get(),
+            msg="Cache is not initialized,"
+                " but access should return None instead of crashing")
+
+    def test_middleware_active(self):
+        def view(_request):
+            self.assertIsNotNone(
+                scoped_cache_context_var.get(),
+                msg="Cache should be initialized")
+            return 'response'
+        ViewScopedCacheMiddleware(view)('request')
+
+    def test_task_active(self):
+        @full_job()
+        def job_example():
+            self.assertIsNotNone(
+                scoped_cache_context_var.get(),
+                msg="Cache should be initialized")
+            return "Result message"
+
+        job_example()
+
+        job = Job.objects.latest('pk')
+        self.assertEqual(
+            job.result_message, "Result message", msg="Job shouldn't crash")
+
+    def test_decorator_active(self):
+        @context_scoped_cache()
+        def func():
+            self.assertIsNotNone(
+                scoped_cache_context_var.get(),
+                msg="Cache should be initialized")
+
+        func()
+
+    def test_cache_usage(self):
+        computed_value = 1
+
+        def compute():
+            return computed_value
+
+        cacheable_value = CacheableValue(
+            cache_key='key',
+            compute_function=compute,
+            cache_update_interval=60*60,
+            cache_timeout_interval=60*60,
+            use_context_scoped_cache=True,
+        )
+
+        def view(_request):
+            self.assertEqual(cacheable_value.get(), 1)
+            return 'response'
+        ViewScopedCacheMiddleware(view)('request')
+
+        computed_value = 2
+        self.assertEqual(compute(), 2, "This var scoping should work")
+
+        def view(_request):
+            # Django cache and view-scoped cache still have the old value
+            self.assertEqual(cache.get(cacheable_value.cache_key), 1)
+            self.assertEqual(cacheable_value.get(), 1)
+
+            # Django cache is updated; view-scoped cache still has old value
+            cache.set(cacheable_value.cache_key, compute())
+            self.assertEqual(cache.get(cacheable_value.cache_key), 2)
+            self.assertEqual(cacheable_value.get(), 1)
+
+            # Both caches are updated
+            cacheable_value.update()
+            self.assertEqual(cache.get(cacheable_value.cache_key), 2)
+            self.assertEqual(cacheable_value.get(), 2)
+
+            return 'response'
+        ViewScopedCacheMiddleware(view)('request')
+
+    def test_value_not_cached_in_next_view(self):
+        computed_value = 1
+
+        def compute():
+            return computed_value
+
+        cacheable_value = CacheableValue(
+            cache_key='key',
+            compute_function=compute,
+            cache_update_interval=60*60,
+            cache_timeout_interval=60*60,
+            use_context_scoped_cache=True,
+        )
+        with context_scoped_cache():
+            cacheable_value.update()
+
+        computed_value = 2
+
+        def view(_request):
+            # Django cache and view-scoped cache still have the old value
+            self.assertEqual(cache.get(cacheable_value.cache_key), 1)
+            self.assertEqual(cacheable_value.get(), 1)
+
+            # Django cache is updated; view-scoped cache still has old value
+            cache.set(cacheable_value.cache_key, compute())
+            self.assertEqual(cache.get(cacheable_value.cache_key), 2)
+            self.assertEqual(cacheable_value.get(), 1)
+
+            return 'response'
+        ViewScopedCacheMiddleware(view)('request')
+
+        def view(_request):
+            # View-scoped cache is updated because a new view has started
+            self.assertEqual(cache.get(cacheable_value.cache_key), 2)
+            self.assertEqual(cacheable_value.get(), 2)
+
+            return 'response'
+        ViewScopedCacheMiddleware(view)('request')

--- a/project/lib/tests/test_storage.py
+++ b/project/lib/tests/test_storage.py
@@ -66,7 +66,8 @@ class TestSettingsStorageTest(BaseTest):
 
 
 @skipIf(
-    not settings.DEFAULT_FILE_STORAGE == 'lib.storage_backends.MediaStorageS3',
+    not settings.STORAGES['default']['BACKEND']
+        == 'lib.storage_backends.MediaStorageS3',
     "Requires S3 storage")
 class S3UrlAccessTest(ClientTest):
     """

--- a/project/lib/tests/utils.py
+++ b/project/lib/tests/utils.py
@@ -408,12 +408,7 @@ class ClientUtilsMixin(object, metaclass=ABCMeta):
 
 class CustomTestRunner(DiscoverRunner):
 
-    def run_tests(self, test_labels, extra_tests=None, **kwargs):
-        """
-        extra_tests can be removed from the signature of this method
-        once PyCharm stops using it:
-        https://youtrack.jetbrains.com/issue/PY-53355/Warning-when-running-Django-tests-RemovedInDjango50Warning-The-extratests-argument-is-deprecated
-        """
+    def run_tests(self, test_labels, **kwargs):
         # Make tasks run synchronously. This is needed since the
         # huey consumer would run in a separate process, meaning it
         # wouldn't see the state of the current test's open DB-transaction.

--- a/project/lib/tests/utils.py
+++ b/project/lib/tests/utils.py
@@ -47,34 +47,6 @@ from ..storage_backends import get_storage_manager
 User = get_user_model()
 
 
-# Settings to override in all of our unit tests.
-test_settings = dict()
-
-# For most tests, use a local memory cache instead of a filesystem cache,
-# because there's no reason to persist the cache after a particular test is
-# over. And having to clean up those files after each test is slower +
-# more issue-prone than just using memory.
-#
-# Note that the Django docs have a warning on overriding the CACHES setting.
-# For example, tests that use cached sessions may need some extra care.
-# https://docs.djangoproject.com/en/dev/topics/testing/tools/#overriding-settings
-test_settings['CACHES'] = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-        'LOCATION': 'test',
-    }
-}
-
-# Force spacer jobs to use the dummy extractor.
-# Otherwise tests will run slow.
-test_settings['FORCE_DUMMY_EXTRACTOR'] = True
-# Speed up training setup by requiring as few images as possible.
-test_settings['TRAINING_MIN_IMAGES'] = 3
-# Validation sets vs. training sets should be completely predictable in
-# unit tests.
-test_settings['VALSET_SELECTION_METHOD'] = 'name'
-
-
 # Abstract class
 class ClientUtilsMixin(object, metaclass=ABCMeta):
     """
@@ -446,7 +418,6 @@ class CustomTestRunner(DiscoverRunner):
         return return_code
 
 
-@override_settings(**test_settings)
 class BaseTest(TestCase):
     """
     Base automated-test class.

--- a/project/upload/tests/test_images.py
+++ b/project/upload/tests/test_images.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 from django.conf import settings
 from django.core.files.base import ContentFile
-from django.core.files.storage import DefaultStorage
+from django.core.files.storage import default_storage
 from django.core import mail
 from django.test import override_settings
 from django.urls import reverse
@@ -225,8 +225,7 @@ class UploadImageTest(ClientTest):
         image_id = response_json['image_id']
         img = Image.objects.get(pk=image_id)
 
-        storage = DefaultStorage()
-        self.assertTrue(storage.exists(img.original_file.name))
+        self.assertTrue(default_storage.exists(img.original_file.name))
 
 
 class UploadImageFormatTest(ClientTest):

--- a/project/vision_backend/management/commands/vb_export_spacer_data.py
+++ b/project/vision_backend/management/commands/vb_export_spacer_data.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.core.files.base import ContentFile
 from django.core.management.base import BaseCommand
 from django.db.models import F
-from storages.backends.s3boto3 import S3Boto3Storage
+from storages.backends.s3 import S3Storage
 from tqdm import tqdm
 
 from annotations.models import Label, Annotation
@@ -96,7 +96,7 @@ class Command(BaseCommand):
         self.log("Starting data export with args: [{}]\n{}".
                  format(args_str, '-'*70))
 
-        export_storage = S3Boto3Storage(
+        export_storage = S3Storage(
             bucket_name=options['bucket'], location='')
 
         # Start by exporting the label-set
@@ -117,7 +117,7 @@ class Command(BaseCommand):
                 source.nbr_confirmed_images))
 
             # Establish a new connection for each source.
-            export_storage = S3Boto3Storage(
+            export_storage = S3Storage(
                 bucket_name=options['bucket'], location='')
             # When we copy files from one bucket to another, we'll need to
             # access the boto interface at a lower level.

--- a/project/vision_backend/management/commands/vb_inspect_extracted_features.py
+++ b/project/vision_backend/management/commands/vb_inspect_extracted_features.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 import json
 
-from django.core.files.storage import get_storage_class
+from django.core.files.storage import DefaultStorage
 from django.core.management.base import BaseCommand
 
 from images.models import Image
@@ -17,7 +17,7 @@ class Command(BaseCommand):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.errors = defaultdict(list)
-        self.storage = get_storage_class()()
+        self.storage = DefaultStorage()
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/project/vision_backend/management/commands/vb_inspect_extracted_features.py
+++ b/project/vision_backend/management/commands/vb_inspect_extracted_features.py
@@ -1,7 +1,6 @@
 from collections import defaultdict
 import json
 
-from django.core.files.storage import DefaultStorage
 from django.core.management.base import BaseCommand
 
 from images.models import Image
@@ -17,7 +16,6 @@ class Command(BaseCommand):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.errors = defaultdict(list)
-        self.storage = DefaultStorage()
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/project/vision_backend/models.py
+++ b/project/vision_backend/models.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.core.files.storage import get_storage_class
+from django.core.files.storage import DefaultStorage
 from django.db import models
 from spacer.data_classes import ImageFeatures, ValResults
 from spacer.messages import DataLocation
@@ -56,7 +56,7 @@ class Classifier(models.Model):
     
     @property
     def valres(self) -> ValResults:
-        storage = get_storage_class()()
+        storage = DefaultStorage()
         valres_loc: DataLocation = storage.spacer_data_loc(
             settings.ROBOT_MODEL_VALRESULT_PATTERN.format(pk=self.pk))
 
@@ -125,7 +125,7 @@ class Features(models.Model):
 
     @property
     def data_loc(self):
-        storage = get_storage_class()()
+        storage = DefaultStorage()
         return storage.spacer_data_loc(
             settings.FEATURE_VECTOR_FILE_PATTERN.format(
                 full_image_path=self.image.original_file.name))

--- a/project/vision_backend/models.py
+++ b/project/vision_backend/models.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.core.files.storage import DefaultStorage
+from django.core.files.storage import default_storage
 from django.db import models
 from spacer.data_classes import ImageFeatures, ValResults
 from spacer.messages import DataLocation
@@ -56,8 +56,7 @@ class Classifier(models.Model):
     
     @property
     def valres(self) -> ValResults:
-        storage = DefaultStorage()
-        valres_loc: DataLocation = storage.spacer_data_loc(
+        valres_loc: DataLocation = default_storage.spacer_data_loc(
             settings.ROBOT_MODEL_VALRESULT_PATTERN.format(pk=self.pk))
 
         return ValResults.load(valres_loc)
@@ -125,8 +124,7 @@ class Features(models.Model):
 
     @property
     def data_loc(self):
-        storage = DefaultStorage()
-        return storage.spacer_data_loc(
+        return default_storage.spacer_data_loc(
             settings.FEATURE_VECTOR_FILE_PATTERN.format(
                 full_image_path=self.image.original_file.name))
 

--- a/project/vision_backend/queues.py
+++ b/project/vision_backend/queues.py
@@ -3,13 +3,11 @@ from datetime import timedelta
 from io import BytesIO
 import json
 from logging import getLogger
-import sys
 from typing import Optional, Type
 
 import boto3
 from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
-from django.core.files.storage import DefaultStorage
+from django.core.files.storage import default_storage
 from django.utils import timezone
 from django.utils.module_loading import import_string
 from spacer.messages import JobMsg, JobReturnMsg
@@ -23,9 +21,6 @@ logger = getLogger(__name__)
 
 
 class BaseQueue(abc.ABC):
-
-    def __init__(self):
-        self.storage = DefaultStorage()
 
     @abc.abstractmethod
     def submit_job(self, job: JobMsg, job_id: int, spec_level: SpacerJobSpec):
@@ -69,10 +64,10 @@ class BatchQueue(BaseQueue):
             internal_job_id=internal_job_id, spec_level=spec_level.value)
         batch_job.save()
 
-        job_msg_loc = self.storage.spacer_data_loc(batch_job.job_key)
+        job_msg_loc = default_storage.spacer_data_loc(batch_job.job_key)
         job_msg.store(job_msg_loc)
 
-        job_res_loc = self.storage.spacer_data_loc(batch_job.res_key)
+        job_res_loc = default_storage.spacer_data_loc(batch_job.res_key)
 
         resp = self.batch_client.submit_job(
             jobQueue=settings.BATCH_QUEUES[spec_level],
@@ -143,7 +138,7 @@ class BatchQueue(BaseQueue):
             return None, job.status
 
         # Else: 'SUCCEEDED'
-        job_res_loc = self.storage.spacer_data_loc(job.res_key)
+        job_res_loc = default_storage.spacer_data_loc(job.res_key)
 
         try:
             return_msg = JobReturnMsg.load(job_res_loc)
@@ -170,14 +165,14 @@ class LocalQueue(BaseQueue):
         # Process the job right away.
         return_msg = process_job(job)
 
-        filepath = self.storage.path_join('backend_job_res', f'{job_id}.json')
-        self.storage.save(
+        filepath = default_storage.path_join('backend_job_res', f'{job_id}.json')
+        default_storage.save(
             filepath,
             BytesIO(json.dumps(return_msg.serialize()).encode()))
 
     def get_collectable_jobs(self):
         try:
-            dir_names, filenames = self.storage.listdir('backend_job_res')
+            dir_names, filenames = default_storage.listdir('backend_job_res')
         except FileNotFoundError:
             # Perhaps this is a test run and no results files were created
             # yet (thus, the backend_job_res directory was not created).
@@ -191,11 +186,11 @@ class LocalQueue(BaseQueue):
             self, job_filename: str) -> tuple[Optional[JobReturnMsg], str]:
 
         # Read the job result message
-        filepath = self.storage.path_join('backend_job_res', job_filename)
-        with self.storage.open(filepath) as results_file:
+        filepath = default_storage.path_join('backend_job_res', job_filename)
+        with default_storage.open(filepath) as results_file:
             return_msg = JobReturnMsg.deserialize(json.load(results_file))
         # Delete the job result file
-        self.storage.delete(filepath)
+        default_storage.delete(filepath)
 
         # Unlike BatchQueue, LocalQueue is only aware of the
         # jobs that successfully output their results.

--- a/project/vision_backend/queues.py
+++ b/project/vision_backend/queues.py
@@ -47,7 +47,7 @@ def get_queue_class() -> Type[BaseQueue]:
         settings.SPACER_QUEUE_CHOICE ==
         'vision_backend.queues.BatchQueue'
         and
-        settings.DEFAULT_FILE_STORAGE ==
+        settings.STORAGES['default']['BACKEND'] ==
         'lib.storage_backends.MediaStorageLocal'
         and
         'test' not in sys.argv

--- a/project/vision_backend/queues.py
+++ b/project/vision_backend/queues.py
@@ -41,25 +41,6 @@ class BaseQueue(abc.ABC):
 
 
 def get_queue_class() -> Type[BaseQueue]:
-    """This function is modeled after Django's get_storage_class()."""
-
-    if (
-        settings.SPACER_QUEUE_CHOICE ==
-        'vision_backend.queues.BatchQueue'
-        and
-        settings.STORAGES['default']['BACKEND'] ==
-        'lib.storage_backends.MediaStorageLocal'
-        and
-        'test' not in sys.argv
-    ):
-        # We only raise this in non-test environments, because some tests
-        # are able to use mocks to test BatchQueue while sticking with
-        # local storage.
-        raise ImproperlyConfigured(
-            "Can not use Remote queue with local storage."
-            " Please use S3 storage."
-        )
-
     return import_string(settings.SPACER_QUEUE_CHOICE)
 
 

--- a/project/vision_backend/queues.py
+++ b/project/vision_backend/queues.py
@@ -9,7 +9,7 @@ from typing import Optional, Type
 import boto3
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.core.files.storage import get_storage_class
+from django.core.files.storage import DefaultStorage
 from django.utils import timezone
 from django.utils.module_loading import import_string
 from spacer.messages import JobMsg, JobReturnMsg
@@ -25,7 +25,7 @@ logger = getLogger(__name__)
 class BaseQueue(abc.ABC):
 
     def __init__(self):
-        self.storage = get_storage_class()()
+        self.storage = DefaultStorage()
 
     @abc.abstractmethod
     def submit_job(self, job: JobMsg, job_id: int, spec_level: SpacerJobSpec):

--- a/project/vision_backend/queues.py
+++ b/project/vision_backend/queues.py
@@ -6,6 +6,7 @@ from logging import getLogger
 from typing import Optional, Type
 
 import boto3
+from botocore.exceptions import ClientError
 from django.conf import settings
 from django.core.files.storage import default_storage
 from django.utils import timezone
@@ -142,7 +143,8 @@ class BatchQueue(BaseQueue):
 
         try:
             return_msg = JobReturnMsg.load(job_res_loc)
-        except IOError as e:
+        except (ClientError, IOError) as e:
+            # IOError for local storage, ClientError for S3 storage
             self.handle_job_failure(
                 job,
                 f"Batch job [{job}] succeeded,"

--- a/project/vision_backend/tasks.py
+++ b/project/vision_backend/tasks.py
@@ -5,7 +5,7 @@ from logging import getLogger
 import random
 
 from django.conf import settings
-from django.core.files.storage import get_storage_class
+from django.core.files.storage import DefaultStorage
 from django.db import IntegrityError
 from django.db.models import F
 from django.utils import timezone
@@ -308,7 +308,7 @@ def submit_features(image_id, job_id):
         raise JobError(f"No feature extractor configured for this source.")
 
     # Setup the job payload.
-    storage = get_storage_class()()
+    storage = DefaultStorage()
 
     # Assemble row column information
     rowcols = [(p.row, p.column) for p in Point.objects.filter(image=img)]
@@ -424,7 +424,7 @@ def submit_classifier(source_id, job_id):
         feature_cache_dir = TrainClassifierMsg.FeatureCache.AUTO
 
     # Create TrainClassifierMsg
-    storage = get_storage_class()()
+    storage = DefaultStorage()
     task = TrainClassifierMsg(
         job_token=str(job_id),
         trainer_name='minibatch',
@@ -484,7 +484,7 @@ def deploy(api_job_id, api_unit_order, job_id):
             f" Maybe it was deleted.")
         raise JobError(error_message)
 
-    storage = get_storage_class()()
+    storage = DefaultStorage()
 
     task = ClassifyImageMsg(
         job_token=str(job_id),
@@ -536,7 +536,7 @@ def classify_image(image_id):
             " Feature extraction will be redone to fix this.")
 
     # Create task message
-    storage = get_storage_class()()
+    storage = DefaultStorage()
     msg = ClassifyFeaturesMsg(
         job_token=str(image_id),
         feature_loc=img.features.data_loc,

--- a/project/vision_backend/tasks.py
+++ b/project/vision_backend/tasks.py
@@ -5,7 +5,7 @@ from logging import getLogger
 import random
 
 from django.conf import settings
-from django.core.files.storage import DefaultStorage
+from django.core.files.storage import default_storage
 from django.db import IntegrityError
 from django.db.models import F
 from django.utils import timezone
@@ -307,9 +307,6 @@ def submit_features(image_id, job_id):
     if img.source.feature_extractor is None:
         raise JobError(f"No feature extractor configured for this source.")
 
-    # Setup the job payload.
-    storage = DefaultStorage()
-
     # Assemble row column information
     rowcols = [(p.row, p.column) for p in Point.objects.filter(image=img)]
 
@@ -318,7 +315,7 @@ def submit_features(image_id, job_id):
         job_token=str(job_id),
         extractor=get_extractor(img.source.feature_extractor),
         rowcols=rowcols,
-        image_loc=storage.spacer_data_loc(img.original_file.name),
+        image_loc=default_storage.spacer_data_loc(img.original_file.name),
         feature_loc=img.features.data_loc,
     )
 
@@ -424,20 +421,19 @@ def submit_classifier(source_id, job_id):
         feature_cache_dir = TrainClassifierMsg.FeatureCache.AUTO
 
     # Create TrainClassifierMsg
-    storage = DefaultStorage()
     task = TrainClassifierMsg(
         job_token=str(job_id),
         trainer_name='minibatch',
         nbr_epochs=settings.NBR_TRAINING_EPOCHS,
         clf_type=CLASSIFIER_MAPPINGS[source.feature_extractor],
         labels=labels,
-        features_loc=storage.spacer_data_loc(''),
-        previous_model_locs=[storage.spacer_data_loc(
+        features_loc=default_storage.spacer_data_loc(''),
+        previous_model_locs=[default_storage.spacer_data_loc(
             settings.ROBOT_MODEL_FILE_PATTERN.format(pk=pc.pk))
             for pc in prev_classifiers],
-        model_loc=storage.spacer_data_loc(
+        model_loc=default_storage.spacer_data_loc(
             settings.ROBOT_MODEL_FILE_PATTERN.format(pk=classifier.pk)),
-        valresult_loc=storage.spacer_data_loc(
+        valresult_loc=default_storage.spacer_data_loc(
             settings.ROBOT_MODEL_VALRESULT_PATTERN.format(pk=classifier.pk)),
         feature_cache_dir=feature_cache_dir,
     )
@@ -484,8 +480,6 @@ def deploy(api_job_id, api_unit_order, job_id):
             f" Maybe it was deleted.")
         raise JobError(error_message)
 
-    storage = DefaultStorage()
-
     task = ClassifyImageMsg(
         job_token=str(job_id),
         image_loc=DataLocation(
@@ -495,7 +489,7 @@ def deploy(api_job_id, api_unit_order, job_id):
         extractor=get_extractor(classifier.source.feature_extractor),
         rowcols=[(point['row'], point['column']) for point in
                  api_job_unit.request_json['points']],
-        classifier_loc=storage.spacer_data_loc(
+        classifier_loc=default_storage.spacer_data_loc(
             settings.ROBOT_MODEL_FILE_PATTERN.format(pk=classifier.pk))
     )
     # Note the 'deploy' is called 'classify_image' in spacer.
@@ -536,11 +530,10 @@ def classify_image(image_id):
             " Feature extraction will be redone to fix this.")
 
     # Create task message
-    storage = DefaultStorage()
     msg = ClassifyFeaturesMsg(
         job_token=str(image_id),
         feature_loc=img.features.data_loc,
-        classifier_loc=storage.spacer_data_loc(
+        classifier_loc=default_storage.spacer_data_loc(
             settings.ROBOT_MODEL_FILE_PATTERN.format(pk=classifier.pk)
         )
     )

--- a/project/vision_backend/tests/tasks/test_train.py
+++ b/project/vision_backend/tests/tasks/test_train.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
 from django.conf import settings
-from django.core.files.storage import get_storage_class
+from django.core.files.storage import DefaultStorage
 from django.test import override_settings
 from spacer.data_classes import ValResults
 
@@ -99,7 +99,7 @@ class TrainClassifierTest(BaseTaskTest, JobUtilsMixin):
             '[3900, 4600, 5000, 5100, 5200, 5230, 5220, 5224, 5223, 5223]')
 
         # Also check that the actual classifier is created in storage.
-        storage = get_storage_class()()
+        storage = DefaultStorage()
         self.assertTrue(storage.exists(
             settings.ROBOT_MODEL_FILE_PATTERN.format(pk=classifier.pk)))
 

--- a/project/vision_backend/tests/tasks/test_train.py
+++ b/project/vision_backend/tests/tasks/test_train.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
 from django.conf import settings
-from django.core.files.storage import DefaultStorage
+from django.core.files.storage import default_storage
 from django.test import override_settings
 from spacer.data_classes import ValResults
 
@@ -99,17 +99,17 @@ class TrainClassifierTest(BaseTaskTest, JobUtilsMixin):
             '[3900, 4600, 5000, 5100, 5200, 5230, 5220, 5224, 5223, 5223]')
 
         # Also check that the actual classifier is created in storage.
-        storage = DefaultStorage()
-        self.assertTrue(storage.exists(
+        self.assertTrue(default_storage.exists(
             settings.ROBOT_MODEL_FILE_PATTERN.format(pk=classifier.pk)))
 
         # And that the val results are stored.
         valresult_path = settings.ROBOT_MODEL_VALRESULT_PATTERN.format(
             pk=classifier.pk)
-        self.assertTrue(storage.exists(valresult_path))
+        self.assertTrue(default_storage.exists(valresult_path))
 
         # Check that the point-count in val_res is what it should be.
-        val_res = ValResults.load(storage.spacer_data_loc(valresult_path))
+        val_res = ValResults.load(
+            default_storage.spacer_data_loc(valresult_path))
         points_per_image = PointGen.from_db_value(
             self.source.default_point_generation_method).total_points
         self.assertEqual(

--- a/project/vision_backend/tests/tasks/utils.py
+++ b/project/vision_backend/tests/tasks/utils.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.core.files.storage import DefaultStorage
+from django.core.files.storage import default_storage
 from django.test import override_settings
 
 from images.model_utils import PointGen
@@ -38,8 +38,7 @@ class BaseTaskTest(ClientTest, UploadAnnotationsCsvTestMixin):
         self.source.refresh_from_db()
 
     def assertExistsInStorage(self, filepath):
-        storage = DefaultStorage()
-        self.assertTrue(storage.exists(filepath))
+        self.assertTrue(default_storage.exists(filepath))
 
     @classmethod
     def upload_image_with_annotations(

--- a/project/vision_backend/tests/tasks/utils.py
+++ b/project/vision_backend/tests/tasks/utils.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.core.files.storage import get_storage_class
+from django.core.files.storage import DefaultStorage
 from django.test import override_settings
 
 from images.model_utils import PointGen
@@ -38,7 +38,7 @@ class BaseTaskTest(ClientTest, UploadAnnotationsCsvTestMixin):
         self.source.refresh_from_db()
 
     def assertExistsInStorage(self, filepath):
-        storage = get_storage_class()()
+        storage = DefaultStorage()
         self.assertTrue(storage.exists(filepath))
 
     @classmethod

--- a/project/visualization/tests/test_utils.py
+++ b/project/visualization/tests/test_utils.py
@@ -6,7 +6,7 @@ from PIL import Image as PILImage
 from PIL.Image import SAVE as PIL_SAVE
 from django.conf import settings
 from django.core.files.base import ContentFile
-from django.core.files.storage import DefaultStorage
+from django.core.files.storage import default_storage
 from django.test import override_settings
 
 from images.models import Point
@@ -50,8 +50,7 @@ class LabelPatchGenerationTest(ClientTest):
             self.fail("Error occurred during patch generation: {}".format(msg))
 
         # Then assert the patch was actually generated and that it's RGB
-        storage = DefaultStorage()
-        with storage.open(get_patch_path(point_id)) as fp:
+        with default_storage.open(get_patch_path(point_id)) as fp:
             patch = PILImage.open(fp)
             self.assertEqual(patch.size[0], settings.LABELPATCH_NROWS)
             self.assertEqual(patch.size[1], settings.LABELPATCH_NCOLS)
@@ -145,9 +144,7 @@ class PatchCropTest(ClientTest):
         with mock.patch.object(PILImage.Image, 'save', always_save_png):
             generate_patch_if_doesnt_exist(point.pk)
 
-        storage = DefaultStorage()
-
-        with storage.open(get_patch_path(point.pk)) as fp:
+        with default_storage.open(get_patch_path(point.pk)) as fp:
             patch = PILImage.open(fp)
 
             # The patch should have 1 red pixel in the center (to be exact, the

--- a/project/visualization/tests/test_utils.py
+++ b/project/visualization/tests/test_utils.py
@@ -6,7 +6,7 @@ from PIL import Image as PILImage
 from PIL.Image import SAVE as PIL_SAVE
 from django.conf import settings
 from django.core.files.base import ContentFile
-from django.core.files.storage import get_storage_class
+from django.core.files.storage import DefaultStorage
 from django.test import override_settings
 
 from images.models import Point
@@ -50,7 +50,7 @@ class LabelPatchGenerationTest(ClientTest):
             self.fail("Error occurred during patch generation: {}".format(msg))
 
         # Then assert the patch was actually generated and that it's RGB
-        storage = get_storage_class()()
+        storage = DefaultStorage()
         with storage.open(get_patch_path(point_id)) as fp:
             patch = PILImage.open(fp)
             self.assertEqual(patch.size[0], settings.LABELPATCH_NROWS)
@@ -145,7 +145,7 @@ class PatchCropTest(ClientTest):
         with mock.patch.object(PILImage.Image, 'save', always_save_png):
             generate_patch_if_doesnt_exist(point.pk)
 
-        storage = get_storage_class()()
+        storage = DefaultStorage()
 
         with storage.open(get_patch_path(point.pk)) as fp:
             patch = PILImage.open(fp)

--- a/project/visualization/utils.py
+++ b/project/visualization/utils.py
@@ -7,7 +7,7 @@ import django.db.models.fields as model_fields
 from PIL import Image as PILImage
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.core.files.storage import DefaultStorage
+from django.core.files.storage import default_storage
 from django.db.models import Q
 
 from accounts.utils import get_alleviate_user, get_imported_user, get_robot_user
@@ -135,7 +135,7 @@ def get_patch_path(point_id):
 
 
 def get_patch_url(point_id):
-    return DefaultStorage().url(get_patch_path(point_id))
+    return default_storage.url(get_patch_path(point_id))
 
 
 def generate_patch_if_doesnt_exist(point_id):
@@ -146,12 +146,9 @@ def generate_patch_if_doesnt_exist(point_id):
     :return: None
     """
 
-    # Get the storage class, then get an instance of it.
-    storage = DefaultStorage()
-
     # Check if patch exists for the point
     patch_relative_path = get_patch_path(point_id)
-    if storage.exists(patch_relative_path):
+    if default_storage.exists(patch_relative_path):
         return
 
     # Locate the image.
@@ -165,7 +162,8 @@ def generate_patch_if_doesnt_exist(point_id):
                              * settings.LABELPATCH_SIZE_FRACTION)
 
     # Open the image file.
-    with storage.open(original_image_relative_path) as original_image_file:
+    with default_storage.open(
+            original_image_relative_path) as original_image_file:
 
         # Load the image with Pillow.
         im = PILImage.open(original_image_file)
@@ -203,4 +201,4 @@ def generate_patch_if_doesnt_exist(point_id):
     # This approach should work with both local and remote storage.
     with BytesIO() as stream:
         region.save(stream, 'JPEG')
-        storage.save(patch_relative_path, stream)
+        default_storage.save(patch_relative_path, stream)

--- a/project/visualization/utils.py
+++ b/project/visualization/utils.py
@@ -7,7 +7,7 @@ import django.db.models.fields as model_fields
 from PIL import Image as PILImage
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.core.files.storage import get_storage_class
+from django.core.files.storage import DefaultStorage
 from django.db.models import Q
 
 from accounts.utils import get_alleviate_user, get_imported_user, get_robot_user
@@ -135,7 +135,7 @@ def get_patch_path(point_id):
 
 
 def get_patch_url(point_id):
-    return get_storage_class()().url(get_patch_path(point_id))
+    return DefaultStorage().url(get_patch_path(point_id))
 
 
 def generate_patch_if_doesnt_exist(point_id):
@@ -147,7 +147,7 @@ def generate_patch_if_doesnt_exist(point_id):
     """
 
     # Get the storage class, then get an instance of it.
-    storage = get_storage_class()()
+    storage = DefaultStorage()
 
     # Check if patch exists for the point
     patch_relative_path = get_patch_path(point_id)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,8 +20,8 @@ django-environ@git+https://github.com/joke2k/django-environ.git@a1113e41f134d3a5
 # Compat: Python 3.8-3.12, Django 4.1-5.0
 #
 # Django 4.2+ support hasn't been merged yet, but the PR (816) seems done,
-# so we use a fork-branch at the tip of that PR.
-django-guardian@git+https://github.com/StephenChan/django-guardian.git@django5.0
+# so we use a fork with a version defined at the tip of that PR.
+django-guardian@git+https://github.com/StephenChan/django-guardian.git@2.4.0+coralnet
 
 # Python Imaging Library
 # (A currently active, package friendly fork of the old PIL; endorsed by Django)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,5 @@
-# To see requirements for an installed package, use: pip show <package-name>
+# To see an installed package's dependencies and dependents, use:
+# pip show <package-name>
 
 
 Django>=4.1.9,<4.2
@@ -54,7 +55,7 @@ Markdown>=3.4.3,<3.5
 
 # Generates thumbnails, which are smaller versions of images.
 # Changelog: https://github.com/SmileyChris/easy-thumbnails/blob/master/CHANGES.rst
-# Compat: Python 3.8-3.12, Django 4.2-5.1, Pillow any version
+# Compat: Python 3.8-3.12, Django 4.2-5.0, Pillow any version
 #
 # Starting in 2.7.0, this app sets PIL.ImageFile.LOAD_TRUNCATED_IMAGES to False
 # after each image read, which would force us to set it to True before each of

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,11 @@
 # pip show <package-name>
 
 
-Django>=4.1.9,<4.2
+# Compat: Python 3.8-3.12
+#
+# The patch versions generally have quite useful fixes.
+# But occasionally they do have breaking changes, so watch out.
+Django>=4.2.16,<5.0
 
 # Define environment-specific Django config in a .env file or
 # environment variables.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,9 +10,9 @@ Django>=4.1.9,<4.2
 #
 # The release that added Django 4.2 made the SECRET_KEY setting unstable,
 # and a fix to that has been merged, but isn't in a release yet.
-# (See PR 500 in django-environ.) So we use a specific commit-tree instead
-# of a release number.
-django-environ@git+https://github.com/joke2k/django-environ.git@a1113e41f134d3a5b2b6f98c81539f07da2269a7
+# (See PR 500 in django-environ.)
+# So we use a fork with a version defined after that PR.
+django-environ@git+https://github.com/coralnet/django-environ.git@0.11.2+coralnet
 
 # Per-object permissions for Django.
 # e.g. "can edit this source" not just "can edit sources"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,13 @@ Django>=4.1.9,<4.2
 # Define environment-specific Django config in a .env file or
 # environment variables.
 # Changelog: https://django-environ.readthedocs.io/en/latest/changelog.html
-django-environ==0.10.0
+# Compat: Python 3.6-3.12, Django 2.2-5.0
+#
+# The release that added Django 4.2 made the SECRET_KEY setting unstable,
+# and a fix to that has been merged, but isn't in a release yet.
+# (See PR 500 in django-environ.) So we use a specific commit-tree instead
+# of a release number.
+django-environ@git+https://github.com/joke2k/django-environ.git@a1113e41f134d3a5b2b6f98c81539f07da2269a7
 
 # Per-object permissions for Django.
 # e.g. "can edit this source" not just "can edit sources"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -99,7 +99,7 @@ boto3>=1.26.122,<1.27
 # module imports work.
 # Changelog: https://github.com/jschneier/django-storages/blob/master/CHANGELOG.rst
 # Max compat: Python 3.12, Django 5.0
-django-storages==1.14.4
+django-storages[s3]==1.14.4
 
 # REST API framework.
 # Changelog: https://www.django-rest-framework.org/community/release-notes/

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -98,7 +98,7 @@ boto3>=1.26.122,<1.27
 # Even if a dev machine doesn't use S3, we still want this installed to make
 # module imports work.
 # Changelog: https://github.com/jschneier/django-storages/blob/master/CHANGELOG.rst
-# Max compat: Python 3.12, Django 5.0
+# Compat: Python 3.7-3.12, Django 4.1-5.0
 django-storages[s3]==1.14.4
 
 # REST API framework.
@@ -150,7 +150,7 @@ huey>=2.4.5,<2.5
 # Extension of huey's contrib.djhuey package that allows tasks to be
 # allocated to multiple queues.
 # Changelog: https://github.com/gaiacoop/django-huey/blob/main/CHANGELOG.md
-# Requires: django, huey
+# Compat: Python 3.8-3.12, Django 3.2-5.0, huey 2.0+
 django-huey>=1.1.2,<1.2
 
 # Process management. Doesn't run on Windows (but it can still be installed).
@@ -164,8 +164,8 @@ tqdm==4.65.0
 # Support for rendering markdown as HTML, with extra rendering features over
 # the Markdown package (such as tables). Also includes a fancy Markdown editor,
 # with live preview and drag-and-drop image uploads.
-# Requires: Markdown
 # Changelog: https://github.com/neutronX/django-markdownx/releases
+# Compat: Python 3.6-3.10, Django 3.0-4.2, Markdown unspecified
 django-markdownx>=4.0.7,<4.1
 
 # Scientific computing

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -78,8 +78,8 @@ django-registration==3.4
 
 # Versioning of database objects.
 # Changelog: https://github.com/etianen/django-reversion/blob/master/CHANGELOG.rst
-# Compat: Python 3.7-3.11, Django 3.2-4.2
-django-reversion==5.0.12
+# Compat: Python 3.7-3.11, Django 4.2-5.0
+django-reversion==5.1.0
 
 # Allow Django to connect to a PostgreSQL database.
 # Changelog: https://www.psycopg.org/docs/news.html
@@ -119,8 +119,8 @@ django-storages[s3]==1.14.4
 
 # REST API framework.
 # Changelog: https://www.django-rest-framework.org/community/release-notes/
-# Compat: Python 3.6-3.12, Django 3.0-5.0
-djangorestframework==3.15.1
+# Compat: Python 3.6-3.12, Django 4.2-5.0
+djangorestframework==3.15.2
 
 # Writing tests for database migrations.
 # https://github.com/plumdog/django_migration_testcase/
@@ -176,7 +176,8 @@ supervisor>=4.2.5,<4.3
 
 # Progress bar for CLI
 # Changelog: https://tqdm.github.io/releases/
-tqdm==4.65.0
+# Compat: Python 3.7-3.12
+tqdm==4.66.5
 
 # Support for rendering markdown as HTML, with extra rendering features over
 # the Markdown package (such as tables). Also includes a fancy Markdown editor,

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -59,7 +59,8 @@ easy-thumbnails@git+https://github.com/StephenChan/easy-thumbnails.git@master
 # Add email activation to user registration process;
 # unlike in userena, this is implemented without additional models.
 # Changelog: https://django-registration.readthedocs.io/en/stable/upgrade.html
-django-registration==3.3
+# Compat: Python 3.7-3.11, Django 3.2-4.2
+django-registration==3.4
 
 # Versioning of database objects. Requires django.
 # Changelog: https://github.com/etianen/django-reversion/blob/master/CHANGELOG.rst

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,11 +8,14 @@ Django>=4.1.9,<4.2
 # Changelog: https://django-environ.readthedocs.io/en/latest/changelog.html
 django-environ==0.10.0
 
-# Per-object permissions
+# Per-object permissions for Django.
 # e.g. "can edit this source" not just "can edit sources"
-# Requires: django
 # Changelog: https://github.com/django-guardian/django-guardian/blob/devel/CHANGES
-django-guardian==2.4.0
+# Compat: Python 3.8-3.12, Django 4.1-5.0
+#
+# Django 4.2+ support hasn't been merged yet, but the PR (816) seems done,
+# so we use a fork-branch at the tip of that PR.
+django-guardian@git+https://github.com/StephenChan/django-guardian.git@django5.0
 
 # Python Imaging Library
 # (A currently active, package friendly fork of the old PIL; endorsed by Django)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -52,18 +52,18 @@ pyexcel-xlsx==0.6.0
 # Changelog: https://github.com/Python-Markdown/markdown/blob/master/docs/change_log/index.md
 Markdown>=3.4.3,<3.5
 
-# System for generating smaller versions of images.
-# Requires: django, Pillow
+# Generates thumbnails, which are smaller versions of images.
 # Changelog: https://github.com/SmileyChris/easy-thumbnails/blob/master/CHANGES.rst
+# Compat: Python 3.8-3.12, Django 4.2-5.1, Pillow any version
 #
-# As of 2.7.0 this app sets PIL.ImageFile.LOAD_TRUNCATED_IMAGES to False after
-# each image read, which would force us to set it to True before each of our
-# image reads.
+# Starting in 2.7.0, this app sets PIL.ImageFile.LOAD_TRUNCATED_IMAGES to False
+# after each image read, which would force us to set it to True before each of
+# our image reads.
 # https://github.com/SmileyChris/easy-thumbnails/commit/2abd400c8e005045591eb1003d1dcbc0602923c5
 # So we use our own fork of easy-thumbnails, which changes the behavior to
 # restore the previous LOAD_TRUNCATED_IMAGES value after easy-thumbnails does
 # its thing.
-easy-thumbnails@git+https://github.com/StephenChan/easy-thumbnails.git@master
+easy-thumbnails@git+https://github.com/StephenChan/easy-thumbnails.git@2.9+coralnet
 
 # Add email activation to user registration process;
 # unlike in userena, this is implemented without additional models.

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -98,7 +98,8 @@ boto3>=1.26.122,<1.27
 # Even if a dev machine doesn't use S3, we still want this installed to make
 # module imports work.
 # Changelog: https://github.com/jschneier/django-storages/blob/master/CHANGELOG.rst
-django-storages==1.13.2
+# Max compat: Python 3.12, Django 5.0
+django-storages==1.14.4
 
 # REST API framework.
 # Changelog: https://www.django-rest-framework.org/community/release-notes/

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -62,9 +62,10 @@ easy-thumbnails@git+https://github.com/StephenChan/easy-thumbnails.git@master
 # Compat: Python 3.7-3.11, Django 3.2-4.2
 django-registration==3.4
 
-# Versioning of database objects. Requires django.
+# Versioning of database objects.
 # Changelog: https://github.com/etianen/django-reversion/blob/master/CHANGELOG.rst
-django-reversion==5.0.4
+# Compat: Python 3.7-3.11, Django 3.2-4.2
+django-reversion==5.0.12
 
 # Allow Django to connect to a PostgreSQL database.
 # Changelog: https://www.psycopg.org/docs/news.html

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -105,7 +105,8 @@ django-storages[s3]==1.14.4
 
 # REST API framework.
 # Changelog: https://www.django-rest-framework.org/community/release-notes/
-djangorestframework==3.14.0
+# Compat: Python 3.6-3.12, Django 3.0-5.0
+djangorestframework==3.15.1
 
 # Writing tests for database migrations.
 # https://github.com/plumdog/django_migration_testcase/

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -5,4 +5,5 @@
 # WSGI HTTP server - The layer above Django, and below the overall web
 # server (e.g. nginx)
 # Changelog: http://docs.gunicorn.org/en/stable/news.html
-gunicorn>=20.1.0,<20.2
+# Compat: Python 3.7-3.12
+gunicorn==23.0.0


### PR DESCRIPTION
- Updates Django from 4.1 to 4.2, getting it back onto a currently-supported version. All deprecations have been addressed. The most involved part of this update was the updated storages system, which is relevant to our `lib/storage_backends.py` designs, as well as the packages django-storages and easy-thumbnails.

- Updates various other packages for Django 4.2 support and/or bug fixes.

- Updates test-setup code and test code related to storage, particularly S3 storage. These include some tests that were broken for S3 storage before. However, not all such tests were tended to (in particular, the tests for the inspect-extracted-features management command still fail on S3 storage, possibly just for Windows but not sure).

- Unit tests on S3 storage settings might be noticeably faster now, though I'm not 100% sure since it's been a while since I timed these. But basically I changed it to authenticate to AWS only once, instead of at the start of every test - a similar idea to https://github.com/coralnet/pyspacer/pull/77 . I tried changing just that part back and forth while testing, and the speedup seemed to be like 2-4x.

- Test-specific settings values are all in `settings.py` now, instead of being split between there and `lib/tests/utils.py`.

Unfortunately, the number of packages where we rely on forks has gone up from 1 to 3: previously easy-thumbnails, and now also django-environ and django-guardian. django-environ in particular probably needs to be replaced later, since the maintainers haven't shown any signs for nearly a year. The most logical move in that case would be to move to python-dotenv. django-guardian seems like it was in the midst of a maintainer hand-off recently, but progress has been stalled somewhat, including the PR for official Django 4.2 support.

I did make an improvement to how the fork installations work, though. Instead of making requirements refer to the main/master branch of my fork, I now create a git tag at the desired part of the fork, and then requirements refer to that tag.

For example, `django-environ@git+https://github.com/coralnet/django-environ.git@0.11.2+coralnet`. Here the tag is `0.11.2+coralnet`, denoting that it's based off of the upstream repo's 0.11.2, and using the [PyPA spec's '+' syntax for local version identifiers](https://packaging.python.org/en/latest/specifications/version-specifiers/#local-version-identifiers). That is, the tag's local to a fork, invisible to the upstream project.

This has a couple of benefits:

- The tag marks that commit-tree of the fork for posterity, even if we do more work on the fork in the future and update any of its branches. So that's useful for referencing purposes, and if there's a tag at that point of the fork's history, we're less likely to accidentally delete that commit somehow.

- The local-version tag means less ambiguity for future updates via pip-install. If you just specify a branch-name or commit-hash when pip installing, then pip auto-detects the version identifier at that branch or commit, and considers that the version of your install. For example, the upstream django-environ repo's main branch is already detected as 0.11.3, despite the latest actual release being 0.11.2, since the maintainers chose to pre-emptively put 0.11.3 in the setup.py or something. So if I installed that, and then later they made a 0.11.3 release and I wanted to update to that, pip would basically say "oh, you already have 0.11.3" and not update! But pip has no problem retrieving 0.11.3 if the existing install is registered as 0.11.2+coralnet.