### PR TITLE
collect_spacer_jobs(): Collect jobs in pk order (FIFO)

### DIFF
--- a/project/vision_backend/queues.py
+++ b/project/vision_backend/queues.py
@@ -100,8 +100,10 @@ class BatchQueue(BaseQueue):
 
     def get_collectable_jobs(self):
         # Not-yet-collected BatchJobs.
-        return BatchJob.objects.exclude(
-            status__in=['SUCCEEDED', 'FAILED']
+        return (
+            BatchJob.objects
+            .exclude(status__in=['SUCCEEDED', 'FAILED'])
+            .order_by('pk')
         )
 
     def collect_job(self, job: BatchJob) -> tuple[Optional[JobReturnMsg], str]:


### PR DESCRIPTION
Used to be an arbitrary order. Normally this doesn't make a ton of difference, except when the server is overloaded enough that collect_spacer_jobs() consistently times out - as a result of both high spacer job volume, and this job only being able to run a couple times a day, as has been the case recently. In that case, some spacer jobs might remain uncollected indefinitely. I just verified in manage.py-shell that the arbitrary order is quite jumbled in terms of pk, so many of the earliest jobs are very much not at the front of the line.

Note that when a spacer job gets collected after a long time, like 10-14 days in some recent cases, the Batch token may no longer be saved in AWS. If this happens, CoralNet should already do the reasonable thing by marking the job as failed so that a replacement Batch job can be submitted. However, many of the earliest jobs aren't even getting to that point where they can be marked as failed to retry. Hopefully this fix gets those jobs back on track.