### PR TITLE
Reset-classifiers job: chunking to avoid crashes, and safer timing

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -106,8 +106,9 @@ SECRET_KEY=
 #MEDIA_URL=http://localhost:8070/
 #STATIC_URL=http://127.0.0.1:8080/
 
-# This should log database queries to a file in your LOG_DIR. Useful when
-# debugging database-querying code.
+# This should log database queries to a file in your LOG_DIR, as long as you
+# have force_debug_cursor set as described in settings.py.
+# Useful when debugging database-querying code.
 #LOG_DATABASE_QUERIES=True
 
 

--- a/project/annotations/views.py
+++ b/project/annotations/views.py
@@ -152,7 +152,7 @@ def batch_delete_annotations_ajax(request, source_id):
     image_count = image_set.count()
 
     # Delete annotations.
-    Annotation.objects.filter(image__in=image_set).delete()
+    Annotation.objects.filter(image__in=image_set).delete_in_chunks()
 
     # This should appear on the next browse load.
     messages.success(

--- a/project/config/settings.py
+++ b/project/config/settings.py
@@ -320,6 +320,14 @@ IMAGE_UPLOAD_ACCEPTED_CONTENT_TYPES = [
 ]
 CSV_UPLOAD_MAX_FILE_SIZE = 30*1024*1024  # 30 MB
 
+# [CoralNet setting]
+# Sometimes we specify a really large queryset and anticipate that our code
+# will induce Django to load it all into memory. For example, QuerySet.delete()
+# seems to do this if there are any SET_NULL foreign keys pointing to the model
+# in question. In these cases, we can code it in such a way that the objects
+# are loaded in chunks so that we don't run out of memory.
+QUERYSET_CHUNK_SIZE = 100000
+
 
 #
 # PySpacer and the vision backend
@@ -1191,6 +1199,9 @@ LOGGING = {
     },
 }
 # This can help with debugging DB queries.
+# Note: you must set django.db.connection.force_debug_cursor to True
+# before the code of interest to actually log any non-schema queries.
+# Then set to False when you don't need to log any more.
 if env.bool('LOG_DATABASE_QUERIES', default=False):
     LOGGING['handlers']['database'] = {
         'filename': LOG_DIR / 'database.log',

--- a/project/images/tests/test_image_detail_actions.py
+++ b/project/images/tests/test_image_detail_actions.py
@@ -382,6 +382,28 @@ class RegeneratePointsTest(ImageDetailActionBaseTest):
     def test_show_button_if_no_annotations(self):
         self.assertLinkPresent(self.user, self.img)
 
+    def test_reset_features(self):
+        """
+        If we generate new points, features must be reset.
+        """
+        image = self.upload_image(self.user, self.source)
+        image.features.extracted = True
+        image.features.save()
+        robot = self.create_robot(self.source)
+        self.add_robot_annotations(robot, image)
+
+        image.features.refresh_from_db()
+        image.annoinfo.refresh_from_db()
+        self.assertTrue(image.features.extracted, "Should have features")
+        self.assertTrue(image.annoinfo.classified, "Should be classified")
+
+        self.post_to_action_view(self.user, image)
+
+        image.features.refresh_from_db()
+        image.annoinfo.refresh_from_db()
+        self.assertFalse(image.features.extracted, "Features should be reset")
+        self.assertFalse(image.annoinfo.classified, "Should not be classified")
+
 
 class ResetPointGenTest(ImageDetailActionBaseTest):
     action_url_name = 'image_reset_point_generation_method'

--- a/project/jobs/tasks.py
+++ b/project/jobs/tasks.py
@@ -64,10 +64,16 @@ def run_scheduled_jobs():
 
     for job in jobs_to_run:
         try:
-            start_job(job)
+            started = start_job(job)
         except UnrecognizedJobNameError:
             finish_job(
                 job, success=False, result_message="Unrecognized job name")
+            continue
+
+        if not started:
+            # May refuse to start if the start condition for the job is
+            # currently not met.
+            # Try again next time.
             continue
 
         jobs_ran += 1

--- a/project/jobs/tests/utils.py
+++ b/project/jobs/tests/utils.py
@@ -83,7 +83,7 @@ def do_job(
     now = datetime.now(timezone.utc)
 
     if created:
-        start_job(job)
+        started = start_job(job)
     else:
         if job.status == Job.Status.PENDING:
             if job.scheduled_start_date < now:
@@ -92,8 +92,12 @@ def do_job(
                 # since it can be misleading.
                 job.scheduled_start_date = None
                 job.save()
-            start_job(job)
-        # Else, the same job was already existing and running.
+            started = start_job(job)
+        else:
+            # The same job was already existing and running.
+            started = True
+
+    assert started, "Expected to start the job, but start condition not met."
 
     job.refresh_from_db()
     return job

--- a/project/lib/tests/utils.py
+++ b/project/lib/tests/utils.py
@@ -1470,3 +1470,17 @@ def make_media_url_comparable(url):
     comparable_url = urlunsplit(
         urlsplit(url)._replace(query=urlencode(comparable_query_args)))
     return comparable_url
+
+
+def spy_decorator(method_to_decorate):
+    """
+    A way to track calls to a class's instance method, across all instances
+    of the class. From:
+    https://stackoverflow.com/a/41599695
+    """
+    mock_obj = mock.MagicMock()
+    def wrapper(self, *args, **kwargs):
+        mock_obj(*args, **kwargs)
+        return method_to_decorate(self, *args, **kwargs)
+    wrapper.mock_obj = mock_obj
+    return wrapper

--- a/project/vision_backend/tasks.py
+++ b/project/vision_backend/tasks.py
@@ -652,9 +652,34 @@ def reset_classifiers_for_source(source_id):
     """
     Removes all traces of the classifiers for this source.
     """
+    # Nobody has foreign keys to Scores, so this is one efficient query.
     Score.objects.filter(source_id=source_id).delete()
+
+    # There are SET_NULL FKs to Annotations, so deletion would induce Django
+    # to fetch all Annotations as part of implementing setting null. This could
+    # run us out of memory with production amounts of Annotations, so we chunk
+    # it.
+    # We also use only() to reduce what's fetched.
+    #
+    # We do this before deleting Classifiers, since Annotations have FKs to
+    # Classifiers, but not vice versa. So this order should reduce a bit of
+    # work, and also makes more sense from a data consistency standpoint.
+    annotations = (
+        Annotation.objects.filter(source_id=source_id)
+        .unconfirmed()
+        .only('pk')
+    )
+    while True:
+        chunk_pks = annotations[:settings.QUERYSET_CHUNK_SIZE].values('pk')
+        if chunk_pks:
+            Annotation.objects.filter(pk__in=chunk_pks).only('pk').delete()
+        else:
+            break
+
+    # There are SET_NULL FKs to Classifiers, so this fetches all classifiers to
+    # implement setting null. But that's okay since there aren't many
+    # classifiers per source.
     Classifier.objects.filter(source_id=source_id).delete()
-    Annotation.objects.filter(source_id=source_id).unconfirmed().delete()
 
     # Can probably train a new classifier.
     schedule_source_check(source_id)

--- a/project/vision_backend/tests/tasks/test_misc.py
+++ b/project/vision_backend/tests/tasks/test_misc.py
@@ -1,22 +1,22 @@
 from unittest import mock
 
 from django.test.utils import override_settings
-from django.urls import reverse
 
 from annotations.managers import AnnotationQuerySet
 from annotations.models import Annotation
 from jobs.models import Job
-from jobs.tasks import run_scheduled_jobs_until_empty
-from jobs.tests.utils import do_job
-from jobs.utils import schedule_job
+from jobs.tasks import run_scheduled_jobs, run_scheduled_jobs_until_empty
+from jobs.tests.utils import do_job, fabricate_job
+from jobs.utils import abort_job, schedule_job
 from lib.tests.utils import spy_decorator
 from ...models import Score, Classifier
-from .utils import BaseTaskTest, do_collect_spacer_jobs
+from .utils import (
+    BaseTaskTest, do_collect_spacer_jobs, source_check_is_scheduled)
 
 
-class ResetTaskTest(BaseTaskTest):
+class ResetClassifiersForSourceTest(BaseTaskTest):
 
-    def test_reset_classifiers_for_source(self):
+    def test_main(self):
 
         # Classify image and verify that it worked
 
@@ -36,17 +36,23 @@ class ResetTaskTest(BaseTaskTest):
             Annotation.objects.filter(image=img).count(), 0,
             "img should have annotations")
 
+        # Classify probably scheduled a source check; run that so we don't have
+        # any incomplete jobs remaining.
+        run_scheduled_jobs()
+
         # Reset classifiers
-        job, _ = schedule_job(
+        job = do_job(
             'reset_classifiers_for_source', self.source.pk,
             source_id=self.source.pk)
-        run_scheduled_jobs_until_empty()
 
-        job.refresh_from_db()
         self.assertEqual(
             job.status, Job.Status.SUCCESS, "Job should be marked as succeeded")
         self.assertTrue(
             job.persist, "Job should be marked as persistent")
+        self.assertTrue(
+            source_check_is_scheduled(self.source.pk),
+            msg="Should schedule a check after reset",
+        )
 
         # Verify that classifier-related objects were cleared, but not features
 
@@ -91,17 +97,18 @@ class ResetTaskTest(BaseTaskTest):
                 "Confirmed image should still be confirmed")
 
     @override_settings(QUERYSET_CHUNK_SIZE=10)
-    def test_reset_classifiers_in_chunks(self):
+    def test_chunks(self):
 
         self.upload_data_and_train_classifier()
 
-        # 5x5 = 25 unconfirmed annotations
         for _ in range(5):
             self.upload_image_and_machine_classify()
-
         self.assertEqual(
             self.source.annotation_set.unconfirmed().count(), 25,
-            "Should have expected number of unconfirmed annotations")
+            "Should have 5x5 = 25 unconfirmed annotations")
+
+        # Finish the scheduled source check.
+        run_scheduled_jobs()
 
         # Reset classifiers, while tracking how many chunks are used when
         # deleting the unconfirmed annotations.
@@ -125,7 +132,7 @@ class ResetTaskTest(BaseTaskTest):
             self.source.classifier_set.count(), 0,
             "Should have no classifier left")
 
-    def test_reset_classifiers_doesnt_affect_other_sources(self):
+    def test_doesnt_affect_other_sources(self):
 
         self.upload_data_and_train_classifier()
         self.upload_data_and_train_classifier()
@@ -138,6 +145,8 @@ class ResetTaskTest(BaseTaskTest):
         for _ in range(3):
             self.upload_image_and_machine_classify(source=source_2)
 
+        # Finish self.source's scheduled source check.
+        run_scheduled_jobs()
         do_job(
             'reset_classifiers_for_source', self.source.pk,
             source_id=self.source.pk)
@@ -156,51 +165,113 @@ class ResetTaskTest(BaseTaskTest):
             source_2.classifier_set.count(), 0,
             "source_2 should still have a classifier")
 
-    def test_reset_features_for_source(self):
+    def test_source_check_during_reset(self):
+        schedule_job(
+            'reset_classifiers_for_source', self.source.pk,
+            source_id=self.source.pk)
+        self.source_check_and_assert(
+            "Waiting for reset job to finish",
+            assert_msg="Check shouldn't proceed during reset job")
+
+    def test_reset_during_core_job(self):
+        # Make this job start as in-progress so that it's not picked up
+        # by run_scheduled_jobs().
+        check_job = fabricate_job(
+            'check_source', self.source.pk,
+            source_id=self.source.pk,
+            status=Job.Status.IN_PROGRESS,
+        )
+
+        reset_job, _ = schedule_job(
+            'reset_classifiers_for_source', self.source.pk,
+            source_id=self.source.pk)
+        # This should just pick up the reset job.
+        run_scheduled_jobs()
+
+        reset_job.refresh_from_db()
+        self.assertEqual(
+            reset_job.status, Job.Status.PENDING,
+            msg="Reset job shouldn't have started due to the incomplete"
+                " core job (the source check)")
+
+        # Make the check job no longer active.
+        abort_job(check_job.pk)
+        # Try the reset job again.
+        run_scheduled_jobs()
+
+        reset_job.refresh_from_db()
+        self.assertEqual(
+            reset_job.status, Job.Status.SUCCESS,
+            msg="Reset job should have been able to run this time")
+
+
+class ResetFeaturesForSourceTest(BaseTaskTest):
+
+    def test_main(self):
 
         img = self.upload_image(self.user, self.source)
         run_scheduled_jobs_until_empty()
         do_collect_spacer_jobs()
         self.assertTrue(img.features.extracted, "img should have features")
 
+        # Abort the scheduled source check.
+        abort_job(self.get_latest_job_by_name('check_source').pk)
         # Reset features
-        job, _ = schedule_job(
-            'reset_features_for_source', self.source.pk,
-            source_id=self.source.pk)
-        run_scheduled_jobs_until_empty()
+        with self.captureOnCommitCallbacks(execute=True):
+            job = do_job(
+                'reset_features_for_source', self.source.pk,
+                source_id=self.source.pk)
 
-        job.refresh_from_db()
         self.assertEqual(
             job.status, Job.Status.SUCCESS, "Job should be marked as succeeded")
+        self.assertTrue(
+            source_check_is_scheduled(self.source.pk),
+            msg="Should schedule a check after reset",
+        )
 
         # Verify that features were cleared
 
         img.features.refresh_from_db()
         self.assertFalse(img.features.extracted, "img shouldn't have features")
 
-    def test_point_change_cleanup(self):
-        """
-        If we generate new points, features must be reset.
-        """
-        image = self.upload_image(self.user, self.source)
-        image.features.extracted = True
-        image.features.save()
-        robot = self.create_robot(self.source)
-        self.add_robot_annotations(robot, image)
+    def test_source_check_during_reset(self):
+        schedule_job(
+            'reset_features_for_source', self.source.pk,
+            source_id=self.source.pk)
+        self.source_check_and_assert(
+            "Waiting for reset job to finish",
+            assert_msg="Check shouldn't proceed during reset job")
 
-        image.features.refresh_from_db()
-        image.annoinfo.refresh_from_db()
-        self.assertTrue(image.features.extracted, "Should have features")
-        self.assertTrue(image.annoinfo.classified, "Should be classified")
+    def test_reset_during_core_job(self):
+        # Make this job start as in-progress so that it's not picked up
+        # by run_scheduled_jobs().
+        check_job = fabricate_job(
+            'check_source', self.source.pk,
+            source_id=self.source.pk,
+            status=Job.Status.IN_PROGRESS,
+        )
 
-        self.client.force_login(self.user)
-        url = reverse('image_regenerate_points', args=[image.id])
-        self.client.post(url)
+        reset_job, _ = schedule_job(
+            'reset_features_for_source', self.source.pk,
+            source_id=self.source.pk)
+        # This should just pick up the reset job.
+        run_scheduled_jobs()
 
-        image.features.refresh_from_db()
-        image.annoinfo.refresh_from_db()
-        self.assertFalse(image.features.extracted, "Should not have features")
-        self.assertFalse(image.annoinfo.classified, "Should not be classified")
+        reset_job.refresh_from_db()
+        self.assertEqual(
+            reset_job.status, Job.Status.PENDING,
+            msg="Reset job shouldn't have started due to the incomplete"
+                " core job (the source check)")
+
+        # Make the check job no longer active.
+        abort_job(check_job.pk)
+        # Try the reset job again.
+        run_scheduled_jobs()
+
+        reset_job.refresh_from_db()
+        self.assertEqual(
+            reset_job.status, Job.Status.SUCCESS,
+            msg="Reset job should have been able to run this time")
 
 
 def schedule_collect_spacer_jobs():

--- a/project/vision_backend/utils.py
+++ b/project/vision_backend/utils.py
@@ -213,25 +213,21 @@ def schedule_source_check_on_commit(source_id, delay=None):
     )
 
 
-def source_is_finished_with_core_jobs(
-    source_id: int,
-    job_id_about_to_finish: int = None,
-) -> bool:
+def source_is_finished_with_core_jobs(source_id: int) -> bool:
     """
     Is the source still running any 'core' vision-backend jobs?
-    This quick confirmation can be useful when deciding whether to run
-    another source check.
-
-    If this is called from a core job which is about to finish (and thus we
-    don't want to count that job), that job's ID can be passed as
-    job_id_about_to_finish.
+    This quick confirmation can be useful, for example, when deciding
+    whether to run another source check.
     """
     core_source_job_names = [
-        'extract_features', 'train_classifier', 'classify_features']
+        'extract_features',
+        'train_classifier',
+        'classify_features',
+        'check_source',
+    ]
     incomplete_core_jobs = (
         Job.objects
         .filter(source_id=source_id, job_name__in=core_source_job_names)
-        .exclude(pk=job_id_about_to_finish)
         .incomplete()
     )
     return not incomplete_core_jobs.exists()


### PR DESCRIPTION
Two main things in this PR.

## 1. Preventing reset-classifiers crashes

The last 3 server crashes (all in the past 1.5 months) seemed to happen during `reset_classifiers_for_source` jobs on large sources.

From the [Django docs on QuerySet.delete()](https://docs.djangoproject.com/en/4.2/ref/models/querysets/#delete):

> By default, Django’s ForeignKey emulates the SQL constraint ON DELETE CASCADE — in other words, any objects with foreign keys pointing at the objects to be deleted will be deleted along with them. ... This cascade behavior is customizable via the on_delete argument to the ForeignKey.
>
> The delete() method does a bulk delete and does not call any delete() methods on your models. It does, however, emit the pre_delete and post_delete signals for all deleted objects (including cascaded deletions).
>
> Django needs to fetch objects into memory to send signals and handle cascades. However, if there are no cascades and no signals, then Django may take a fast-path and delete objects without fetching into memory. For large deletes this can result in significantly reduced memory usage. The amount of executed queries can be reduced, too.

"May" take a fast-path. I checked out the DB queries that were run during `reset_classifiers_for_source`.

- For deleting Scores, it seems to take the fast path; Scores don't have to be fetched before making the queries to delete them. This is probably thanks to the fact that no foreign keys point to Scores.
- For deleting Classifiers, it doesn't take the fast path; all Classifiers have to be fetched before making the queries to delete them. One reason is probably that there are `SET_NULL` foreign keys pointing to Classifiers, meaning that those foreign keys are supposed to be set to null when the classifiers in question are deleted. However, this is an acceptable situation because there aren't many Classifiers per source, and thus not very many can be deleted at once.
- For deleting unconfirmed Annotations, it doesn't take the fast path, similarly to Classifiers. But there can be 100k's, or even around a million unconfirmed Annotations in a single source, which can certainly demand enough memory to cause problems. Not unlike the export-annotations crashes we used to get, I guess.

So I reworked the annotation deletion part to delete in chunks of max size 100k. This is basically done by slicing the annotation queryset in a while-loop.

I also applied the chunking logic to the batch annotation deletion available from Browse Images, since if I'm right, that would have the potential to crash in the same way.

## 2. Safer timing of reset-classifiers and reset-features jobs relative to other jobs

While I was at it, the out-of-band nature of the reset jobs has been making me uneasy. In terms of data consistency, and also now that we don't run fallback source-checks every day. So now we have this logic:

- Don't proceed with a source check if a reset job is active. In other words, the source check returns near the beginning of the check function, with an appropriate message: "Waiting for reset job to finish".
- Don't start a reset job if extract/train/classify/check jobs are active. In other words, `run_scheduled_jobs()` skips over the reset job whenever this is the case. The next periodic runs of `run_scheduled_jobs()` will continue checking this condition until the reset job is clear to run.

And with the first point in mind, I also tried to increase the guarantee that the end-of-reset-job source checks would be scheduled strictly after the reset job finished, instead of potentially trying to start while the reset job was still finishing.