### PR TITLE
update_label_details performance improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,11 @@ For info about the semantic versioning used here, see `docs/versions.rst`.
 
 ## 1.15 (WIP)
 
-- New migrations to run for: `annotations`, `events`, `jobs`, `vision_backend`.
-- The new `CORALNET_1_15_DATE` setting may have to be specified.
+- New migrations to run for: `annotations`, `events`, `vision_backend`.
+  - Before restarting the web server, run everything except annotations 0027. annotations 0027 is expected to take a while, but it can run while the web server's running.
+- Ensure the cached label details are updated before restarting the production web server. Otherwise, visiting the label_main pages will get errors.
+  - To do this, start the background-queue huey consumer without starting the web server. Then in manage.py shell, run `job = do_job('update_label_details')`. Do `job.refresh_from_db()` every so often until `job.status` is `success`.
+- The new `CORALNET_1_15_DATE` setting must be specified for production, and may have to be specified more accurately in other envs.
 
 ## [1.14](https://github.com/coralnet/coralnet/tree/1.14)
 

--- a/project/labels/forms.py
+++ b/project/labels/forms.py
@@ -19,7 +19,7 @@ from lib.forms import (
     BoxFormRenderer, FieldsetsFormComponent, get_one_form_error)
 from upload.utils import csv_to_dicts
 from .models import Label, LabelGroup, LabelSet, LocalLabel
-from .utils import search_labels_by_text
+from .utils import label_popularity, search_labels_by_text
 
 
 def labels_csv_process(csv_stream, source):
@@ -284,7 +284,7 @@ class LabelSearchForm(FieldsetsFormComponent, Form):
             # list here.
             labels = [
                 label for label in labels
-                if label.popularity >= min_popularity]
+                if label_popularity(label.pk) >= min_popularity]
 
         return labels
 

--- a/project/labels/tasks.py
+++ b/project/labels/tasks.py
@@ -1,5 +1,5 @@
 from jobs.utils import job_runner
-from .models import cacheable_label_details
+from .utils import cacheable_label_details
 
 
 @job_runner(interval=cacheable_label_details.cache_update_interval)

--- a/project/labels/templates/labels/label_basic_fields.html
+++ b/project/labels/templates/labels/label_basic_fields.html
@@ -1,5 +1,4 @@
-{% load labels %}
-{% load truncate_float from common_tags %}
+{% load popularity_bar popularity_value status_icon from labels %}
 
 <div class="line">Name: {{ label.name }}</div>
 <div class="line">Functional Group: {{ label.group.name }}</div>
@@ -24,6 +23,6 @@
 </div>
 
 <div class="line">Popularity:
-  {{ label.popularity|truncate_float }}%
+  {% popularity_value label %}%
   {% popularity_bar label %}
 </div>

--- a/project/labels/templates/labels/label_detail_box.html
+++ b/project/labels/templates/labels/label_detail_box.html
@@ -1,5 +1,4 @@
 {% load static %}
-{% load truncate_float from common_tags %}
 
 {% load calcify_rate_indicator from calcification %}
 
@@ -20,7 +19,7 @@
          data-src="{{ label.thumbnail.url }}"
          class="label-thumbnail lazy-load" alt="{{ label.name }}"/>
   {% else %}
-    <img src="{% static "img/placeholders/media-no-image-available__150x150.png" %}"
+    <img src="{% static 'img/placeholders/media-no-image-available__150x150.png' %}"
          class="label-thumbnail" alt="{{ label.name }}" />
   {% endif %}
 

--- a/project/labels/templates/labels/list_duplicates.html
+++ b/project/labels/templates/labels/list_duplicates.html
@@ -5,22 +5,25 @@
 
 <p>A duplicate label can still be used, but we encourage using the verified label instead.</p>
 
-<p>In total {{stats.dup_count}} duplicates has been identified with a total of {{stats.ann_count}} annotations.</p>
-<table class="detail_table_popup">
-<tr>
-    <th>Label</th>
-    <th>is duplicate of</th>
-    <th>Annotation count</th>
-</tr>
-{% for dup in labels %}
+<p>In total, {{ duplicates|length }} duplicates have been identified, with a total of {{ annotation_total }} confirmed annotations.</p>
+
+<table class="detail_table">
+  <thead>
     <tr>
-        <th><a href="{% url 'label_main' dup.id %}" style="color: green">{{ dup }}</a></th>
-        <th><a href="{% url 'label_main' dup.duplicate.id %}" style="color: green">{{ dup.duplicate }}</a></th>
-        <th>{{ dup.ann_count }}</th>
+      <th>Label</th>
+      <th>is duplicate of</th>
+      <th>Annotation count</th>
     </tr>
-
-{% endfor %}
-
+  </thead>
+  <tbody>
+    {% for dup in duplicates %}
+      <tr>
+        <td><a href="{% url 'label_main' dup.id %}" style="color: green">{{ dup.name }}</a></td>
+        <td><a href="{% url 'label_main' dup.duplicate_id %}" style="color: green">{{ dup.duplicate__name }}</a></td>
+        <td>{{ dup.annotation_count }}</td>
+      </tr>
+    {% endfor %}
+  </tbody>
 </table>
 
 {% endblock %}

--- a/project/labels/templatetags/labels.py
+++ b/project/labels/templatetags/labels.py
@@ -2,12 +2,14 @@ from django import template
 from django.templatetags.static import static
 from django.utils.safestring import mark_safe
 
+from ..utils import label_popularity
+
 register = template.Library()
 
 
 @register.simple_tag
 def popularity_bar(label, short=False):
-    if label.popularity >= 30:
+    if label_popularity(label.pk) >= 30:
         color = 'green'
     else:
         color = 'red'
@@ -18,13 +20,19 @@ def popularity_bar(label, short=False):
         meter_class = 'meter'
 
     # float -> int to truncate decimal, then int -> str
-    bar_width = str(int(label.popularity)) + '%'
+    bar_width = str(int(label_popularity(label.pk))) + '%'
     return mark_safe(
         '<div class="{meter_class}" title="{bar_width}">'
         '  <span class="{color}" style="width: {bar_width};"></span>'
         '</div>'.format(
             meter_class=meter_class, color=color, bar_width=bar_width)
     )
+
+
+@register.simple_tag
+def popularity_value(label):
+    # We display popularity values with the decimal part truncated.
+    return int(label_popularity(label.pk))
 
 
 @register.simple_tag

--- a/project/labels/tests/test_label_main.py
+++ b/project/labels/tests/test_label_main.py
@@ -192,6 +192,11 @@ class LabelMainTest(BaseLabelMainTest):
             name="User's private source")
         self.create_labelset(self.user, user_private_s, labels)
         img = self.upload_image(self.user, user_private_s)
+        # 1 confirmed annotation, and machine annotations which shouldn't
+        # contribute to the count
+        self.add_robot_annotations(
+            self.create_robot(user_private_s), img,
+            {1: 'A', 2: 'A', 3: 'A', 4: 'A', 5: 'A'})
         self.add_annotations(self.user, img, {1: 'A'})
 
         # No annotation, but has A in the labelset

--- a/project/labels/tests/test_label_main.py
+++ b/project/labels/tests/test_label_main.py
@@ -20,6 +20,7 @@ from visualization.utils import get_patch_path
 from ..models import LabelGroup, Label
 from ..templatetags.labels import (
     popularity_bar as popularity_bar_tag, status_icon as status_icon_tag)
+from ..utils import label_popularity
 
 
 class PermissionTest(BasePermissionTest):
@@ -233,7 +234,7 @@ class LabelMainTest(BaseLabelMainTest):
 
         # Popularity.
         with context_scoped_cache():
-            popularity_str = str(int(label_a.popularity)) + '%'
+            popularity_str = str(int(label_popularity(label_a.pk))) + '%'
             popularity_bar_html = popularity_bar_tag(label_a)
         self.assertInHTML(
             'Popularity: {} {}'.format(
@@ -549,7 +550,7 @@ class PopularityTest(ClientTest):
 
         with context_scoped_cache():
             self.assertEqual(
-                self.label_a.popularity, 0,
+                label_popularity(self.label_a.pk), 0,
                 msg="0 sources should mean 0 popularity")
 
     def test_zero_annotations(self):
@@ -561,7 +562,7 @@ class PopularityTest(ClientTest):
 
         with context_scoped_cache():
             self.assertEqual(
-                self.label_a.popularity, 0,
+                label_popularity(self.label_a.pk), 0,
                 msg="1 source and 0 annotations still should mean 0 popularity")
 
     def test_nonzero_annotations(self):
@@ -574,7 +575,7 @@ class PopularityTest(ClientTest):
 
         with context_scoped_cache():
             self.assertGreater(
-                self.label_a.popularity, 0,
+                label_popularity(self.label_a.pk), 0,
                 msg="Non-0 annotations should mean non-0 popularity")
 
 

--- a/project/labels/utils.py
+++ b/project/labels/utils.py
@@ -1,5 +1,9 @@
+import math
 import re
 
+from django.conf import settings
+
+from lib.utils import CacheableValue
 from sources.models import Source
 from .models import Label
 
@@ -55,3 +59,89 @@ def is_label_editable_by_user(label, user):
     # The user is admin of all 1+ sources using this label, and the label
     # isn't verified; OK to edit
     return True
+
+
+def compute_label_details():
+    """
+    Details (which are worth caching) for all labels, including annotation
+    counts and popularities.
+    As of 2023/11, this may take 1.5 hours to run in production.
+
+    Annotation count can take several seconds to compute for a single
+    widely-used label.
+
+    Caching the first page of random patches is good for two reasons:
+    1) On the label detail page, random patch generation involves computing
+    the page count of the entire annotation set, and thus involves at least
+    computing the annotation count.
+    2) We don't have to generate different patch images for different
+    visitors of the label detail page, in most cases. Most folks will only
+    look at the first page of patches (if anything).
+    """
+    labels = Label.objects.all()
+    details = dict()
+
+    for label in labels:
+
+        source_count = label.locallabel_set.count()
+        confirmed_annotation_count = label.annotation_set.confirmed().count()
+
+        # This popularity formula accounts for:
+        # - The number of sources using the label
+        # - The number of confirmed annotations using the label
+        #
+        # Overall, it's not too nuanced, and could use further tinkering
+        # at some point.
+        raw_score = (
+            source_count * math.sqrt(confirmed_annotation_count)
+        )
+        if raw_score == 0:
+            popularity = 0
+        else:
+            # Map to a 0-100 scale.
+            # The exponent determines the "shape" of the mapping.
+            # -0.15 maps raw score of 10 to 29%, 100 to 50%,
+            # 10000 to 75%, and 10000000 to 91%.
+            popularity = 100 * (1 - raw_score**(-0.15))
+
+        # List of annotation IDs to use for the first page of random patches
+        # on the label detail page.
+        random_patches_page_1 = list(
+            label.annotation_set
+            .order_by('?')
+            .values_list('pk', flat=True)
+            [:settings.LABEL_EXAMPLE_PATCHES_PER_PAGE]
+        )
+
+        details[label.pk] = dict(
+            source_count=source_count,
+            confirmed_annotation_count=confirmed_annotation_count,
+            popularity=popularity,
+            random_patches_page_1=random_patches_page_1,
+        )
+
+    return details
+
+
+cacheable_label_details = CacheableValue(
+    cache_key='label_details',
+    compute_function=compute_label_details,
+    cache_update_interval=60*60*24*7,
+    cache_timeout_interval=60*60*24*30,
+    on_demand_computation_ok=False,
+    use_context_scoped_cache=True,
+)
+
+
+def label_confirmed_annotation_count(label_id):
+    label_details = cacheable_label_details.get()
+    if not label_details or label_id not in label_details:
+        return 0
+    return label_details[label_id]['confirmed_annotation_count']
+
+
+def label_popularity(label_id):
+    label_details = cacheable_label_details.get()
+    if not label_details or label_id not in label_details:
+        return 0
+    return label_details[label_id]['popularity']

--- a/project/vision_backend/management/commands/vb_export_spacer_data.py
+++ b/project/vision_backend/management/commands/vb_export_spacer_data.py
@@ -8,7 +8,9 @@ from django.db.models import F
 from storages.backends.s3 import S3Storage
 from tqdm import tqdm
 
-from annotations.models import Label, Annotation
+from annotations.models import Annotation
+from labels.models import Label
+from labels.utils import label_confirmed_annotation_count
 from sources.models import Source
 from sources.utils import filter_out_test_sources
 from .utils import log
@@ -52,13 +54,15 @@ class Command(BaseCommand):
     def labelset_json(self):
         cont = []
         for label in Label.objects.filter():
-            cont.append({'id': label.pk,
-                         'name': label.name,
-                         'code': label.default_code,
-                         'group': label.group.name,
-                         'duplicate_of': str(label.duplicate),
-                         'is_verified': label.verified,
-                         'ann_count': label.ann_count})
+            cont.append({
+                'id': label.pk,
+                'name': label.name,
+                'code': label.default_code,
+                'group': label.group.name,
+                'duplicate_of': str(label.duplicate),
+                'is_verified': label.verified,
+                'ann_count': label_confirmed_annotation_count(label.pk),
+            })
         return json.dumps(cont, indent=2)
 
     @staticmethod


### PR DESCRIPTION
The `update_label_details` job has been taking about 2.5 hours in production. Having a job or request uninterrupted that long holds up other jobs/requests, and is a pain when we want to do server maintenance. I think this is the only job left that goes significantly over 10 minutes.

Here's my attempt at improving the performance of the job, by doing O(1) instead of O(n) counts and random orderings. The annotation counting part will now take about 2 minutes. The example patches part will now take around 9 minutes; this part might still be improvable (I left a comment around that part of the code).

Also moved some stuff from `labels/models.py` to `labels/utils.py`, and there's some associated refactoring.