### PR TITLE
Fix job attempt number logic-regression

### DIFF
--- a/project/jobs/utils.py
+++ b/project/jobs/utils.py
@@ -76,7 +76,11 @@ def get_or_create_job(
         # See if the same job failed last time (if there was a last time).
         # If so, set the attempt count accordingly.
         try:
-            last_completed_job = Job.objects.completed().latest('pk')
+            last_completed_job = (
+                Job.objects.completed()
+                .filter(**job_lookup_kwargs)
+                .latest('pk')
+            )
         except Job.DoesNotExist:
             pass
         else:


### PR DESCRIPTION
Bit of a facepalm regression here, which happened in commit ac14d61 of PR #538 (coralnet 1.12, in production 2024-04-12). It messed up the filtering for getting the last completed job.

As a result of the regression, a single job spec (same name and args) failing repeatedly would almost certainly not get throttled after 5 attempts like it's supposed to, while other completely unrelated jobs would get their attempt number increased to 2. Meanwhile, with an attempt number of 5 being near impossible to reach, we'd never get emailed about a specific repeatedly failing job.