### PR TITLE
More conservative time estimates for annotation export

### DIFF
--- a/project/export/templates/export/annotation_export_wait_times.html
+++ b/project/export/templates/export/annotation_export_wait_times.html
@@ -1,3 +1,3 @@
 <div class="line">
-  Note: This can take a while for large sources. Expect over 1 minute of wait time if you have over 3000 images, or over 200,000 total points.
+  Note: This can take a while for large sources. Expect over 1 minute of wait time if you have over 1000 images, or over 50,000 total points.
 </div>


### PR DESCRIPTION
Since production seems to run it 2-3x slower than staging, despite using the same AWS instance type. Could be due to larger size of the production database, or due to less RAM being available with other requests being serviced.