### PR TITLE
Ensure reset_features_bulk() schedules the expected source checks

### DIFF
--- a/project/vision_backend/tests/tasks/utils.py
+++ b/project/vision_backend/tests/tasks/utils.py
@@ -6,6 +6,7 @@ from annotations.tests.utils import UploadAnnotationsCsvTestMixin
 from images.model_utils import PointGen
 from jobs.models import Job
 from jobs.tests.utils import do_job, JobUtilsMixin
+from jobs.utils import abort_job
 from lib.tests.utils import ClientTest
 from ...models import Classifier
 
@@ -24,6 +25,19 @@ def source_check_is_scheduled(source_id):
     except Job.DoesNotExist:
         return False
     return True
+
+
+def ensure_source_check_not_scheduled(source_id):
+    try:
+        job = Job.objects.get(
+            job_name='check_source',
+            source_id=source_id,
+            status=Job.Status.PENDING,
+        )
+    except Job.DoesNotExist:
+        pass
+    else:
+        abort_job(job.pk)
 
 
 @override_settings(


### PR DESCRIPTION
I noticed that a couple of sources were repeatedly failing training. In both cases, features were being reset because they were pre-2021 features that didn't have valid rowcols (and training now requires valid rowcols). Source checks weren't being scheduled as expected after feature-resetting due to a bug. So, the source checks only happened after a delay, seemingly being triggered by new manual annotations being added. So, when a source check happened, it once again found new confirmed images to add to the dataset... and those once again were images with old features.

If the bug were fixed, then the vision backend should be able to break out of this cycle by doing the source check, doing feature re-extraction, and retrying training before another manual annotation happens. Then it wouldn't have to worry about more feature-resetting until there are enough confirmed images for another training.

The bug was a sneaky one:

```python
def reset_features_bulk(image_queryset):
    """
    Version of reset_features() that is performant for large sets of images.
    """
    features_queryset = Features.objects.filter(image__in=image_queryset)
    features_queryset.update(extracted=False)

    source_ids = image_queryset.values_list('source_id', flat=True).distinct()
    for source_id in source_ids:
        schedule_source_check_on_commit(source_id)
```

If the passed image queryset is specified as "images with features (and optionally some other condition)", the queryset changes after features are reset. Here, `values_list()` basically makes the image queryset get re-evaluated. And the source IDs to run source checks on are derived from the image queryset. So we have to fetch the source IDs *before* features are deleted.