### PR TITLE
Annotation CSVs: Support including both label IDs and codes

### DIFF
--- a/project/annotations/forms.py
+++ b/project/annotations/forms.py
@@ -314,6 +314,7 @@ class ExportAnnotationsForm(Form):
         choices=(
             ('code', "Short codes"),
             ('id', "ID numbers"),
+            ('both', "Both"),
         ),
         initial='code',
         widget=RadioSelect,

--- a/project/annotations/templates/annotations/help_export_csv.html
+++ b/project/annotations/templates/annotations/help_export_csv.html
@@ -10,10 +10,10 @@
   <li><strong>Name</strong>: The name of the image that the annotation is for.</li>
   <li><strong>Row</strong>: Pixel y-position from the top edge of the image.</li>
   <li><strong>Column</strong>: Pixel x-position from the left edge of the image.</li>
-  <li><strong>Label code</strong> or <strong>Label ID</strong>: Label applied to the point.</li>
+  <li><strong>Label code</strong> and/or <strong>Label ID</strong>: Label applied to the point.</li>
 </ul>
 
-<p>The <em>Label format</em> option determines whether labels are written as labelset-defined short codes, or as site-wide label ID numbers. Short codes are more human-readable, while ID numbers can be useful because they are source-independent and very rarely change.</p>
+<p>The <em>Label format</em> option determines whether labels are written as labelset-defined short codes, as site-wide label ID numbers, or both. Short codes are more human-readable, while ID numbers can be useful because they are source-independent and very rarely change.</p>
 
 <p>There are also optional sets of columns available:</p>
 

--- a/project/annotations/templates/annotations/help_upload.html
+++ b/project/annotations/templates/annotations/help_upload.html
@@ -121,6 +121,7 @@ CSV file. It's not much different from creating a typical Excel spreadsheet;
   <li>If your image is 1000 pixels wide, then the possible column numbers are 0 to 999. The same thing applies to row numbers and image height.</li>
   <li>Label codes or IDs in the CSV file must correspond to a label in your source's labelset.</li>
   <li>Label codes are case-insensitive. If your labelset has a label code <code>PORIT</code>, and the CSV file has <code>Porit</code>, then these codes will match.</li>
+  <li>If you have both Label codes and Label IDs in the CSV file (for example, because you exported annotations that way), then IDs will take precedence.</li>
   <li>You may include CSV rows with image names that aren't in your source. Those rows will just be ignored.</li>
   <li>You may include extra CSV columns with names outside of the recognized column names. Those columns will just be ignored.</li>
 </ul>

--- a/project/annotations/tests/test_export_csv.py
+++ b/project/annotations/tests/test_export_csv.py
@@ -387,7 +387,7 @@ class LabelFormatTest(BaseAnnotationExportTest):
     def test_codes(self):
         self.add_annotations(self.user, self.img1, {1: 'B', 2: 'A'})
         post_data = self.default_post_params.copy()
-        post_data['label_format'] = ['code']
+        post_data['label_format'] = 'code'
         response = self.export_annotations(post_data)
 
         expected_lines = [
@@ -400,13 +400,26 @@ class LabelFormatTest(BaseAnnotationExportTest):
     def test_ids(self):
         self.add_annotations(self.user, self.img1, {1: 'B', 2: 'A'})
         post_data = self.default_post_params.copy()
-        post_data['label_format'] = ['id']
+        post_data['label_format'] = 'id'
         response = self.export_annotations(post_data)
 
         expected_lines = [
             'Name,Row,Column,Label ID',
             f'1.jpg,149,99,{self.labels.get(name="B").pk}',
             f'1.jpg,149,299,{self.labels.get(name="A").pk}',
+        ]
+        self.assert_csv_content_equal(response.content, expected_lines)
+
+    def test_both(self):
+        self.add_annotations(self.user, self.img1, {1: 'B', 2: 'A'})
+        post_data = self.default_post_params.copy()
+        post_data['label_format'] = 'both'
+        response = self.export_annotations(post_data)
+
+        expected_lines = [
+            'Name,Row,Column,Label code,Label ID',
+            f'1.jpg,149,99,B,{self.labels.get(name="B").pk}',
+            f'1.jpg,149,299,A,{self.labels.get(name="A").pk}',
         ]
         self.assert_csv_content_equal(response.content, expected_lines)
 

--- a/project/annotations/tests/test_upload_csv_unique_cases.py
+++ b/project/annotations/tests/test_upload_csv_unique_cases.py
@@ -269,40 +269,35 @@ class AnnotationsCSVFormatTest(ClientTest, UploadAnnotationsCsvTestMixin):
 
         self.check(preview_response, upload_response)
 
-    def test_multiple_label_columns(self):
+    def test_label_id_and_code(self):
         """
-        Multiple columns corresponding to the label.
+        ID takes precedence over code.
         """
         rows = [
             ['Name', 'Column', 'Row', 'Label code', 'Label ID'],
-            ['1.png', '', 50, 'A', self.labels.get(name='A').pk],
-            ['1.png', 60, 40, 'B', self.labels.get(name='B').pk],
+            ['1.png', 60, 40, 'B', self.labels.get(name='A').pk],
         ]
         csv_file = self.make_annotations_file('A.csv', rows)
         preview_response = self.preview_annotations(
             self.user, self.source, csv_file)
+        upload_response = self.upload_annotations(self.user, self.source)
 
-        self.assertDictEqual(
-            preview_response.json(),
-            dict(error="CSV cannot have multiple columns specifying the label"
-                       " (Label code, Label ID)"),
-        )
+        self.check(preview_response, upload_response)
 
-    def test_multiple_label_columns_case_insensitive_and_partly_blank(self):
+    def test_label_code_and_label_legacy(self):
+        """
+        Label code takes precedence over Label.
+        """
         rows = [
-            ['Name', 'Column', 'Row', 'LABEL', 'label code'],
-            ['1.png', '', 50, 'A', ''],
-            ['1.png', 60, 40, '', 'B'],
+            ['Name', 'Column', 'Row', 'Label code', 'Label'],
+            ['1.png', 60, 40, 'A', 'B'],
         ]
         csv_file = self.make_annotations_file('A.csv', rows)
         preview_response = self.preview_annotations(
             self.user, self.source, csv_file)
+        upload_response = self.upload_annotations(self.user, self.source)
 
-        self.assertDictEqual(
-            preview_response.json(),
-            dict(error="CSV cannot have multiple columns specifying the label"
-                       " (Label, Label code)"),
-        )
+        self.check(preview_response, upload_response)
 
     def test_field_with_newline(self):
         """Field value with a newline character in it (within quotation marks).

--- a/project/annotations/views.py
+++ b/project/annotations/views.py
@@ -839,13 +839,11 @@ class ExportPrepView(SourceCsvExportPrepView):
         fieldnames = ["Name", "Row", "Column"]
 
         self.label_format = export_form_data['label_format']
-        match self.label_format:
-            case 'code':
-                fieldnames.append("Label code")
-            case 'id':
-                fieldnames.append("Label ID")
-            case _:
-                assert f"Unsupported label format: {self.label_format}"
+
+        if self.label_format in ['code', 'both']:
+            fieldnames.append("Label code")
+        if self.label_format in ['id', 'both']:
+            fieldnames.append("Label ID")
 
         self.labelset_dict = source.labelset.global_pk_to_code_dict()
 
@@ -920,14 +918,11 @@ class ExportPrepView(SourceCsvExportPrepView):
             "Column": point_values['column'],
         }
 
-        match self.label_format:
-            case 'code':
-                row["Label code"] = (
-                    self.labelset_dict[point_values['annotation__label']])
-            case 'id':
-                row["Label ID"] = point_values['annotation__label']
-            case _:
-                assert f"Unsupported label format: {self.label_format}"
+        if self.label_format in ['code', 'both']:
+            row["Label code"] = (
+                self.labelset_dict[point_values['annotation__label']])
+        if self.label_format in ['id', 'both']:
+            row["Label ID"] = point_values['annotation__label']
 
         if 'annotator_info' in self.optional_columns:
             # Truncate date precision at seconds


### PR DESCRIPTION
Adds an option for this in export, and adds support in upload (IDs take precedence if both IDs and codes are present).