### PR TITLE
Support running in a Docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# Include any files or directories that you don't want to be copied to your
+# container here (e.g., local build artifacts, temporary files, etc.).
+#
+# For more help, visit the .dockerignore file reference guide at
+# https://docs.docker.com/go/build-context-dockerignore/
+
+**/.DS_Store
+**/__pycache__
+**/.venv
+**/.classpath
+**/.dockerignore
+**/.env
+**/.git
+**/.gitignore
+**/.project
+**/.settings
+**/.toolstarget
+**/.vs
+**/.vscode
+**/*.*proj.user
+**/*.dbmdl
+**/*.jfm
+**/bin
+**/charts
+**/docker-compose*
+**/compose.y*ml
+**/Dockerfile*
+**/node_modules
+**/npm-debug.log
+**/obj
+**/secrets.dev.yaml
+**/values.dev.yaml
+LICENSE
+README.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,20 +1,65 @@
 # Unique per environment
 .env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
 
 # Generated as needed by maintenanceon command
 project/templates/maintenance_notice.html
 
-# Coverage output files
+# Unit tests/Coverage output files
+htmlcov/
+.tox/
+.nox/
 .coverage
-htmlcov
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
 
 # Sphinx output files
 docs/_build
 docs/_static
 docs/_templates
 
-# Compiled Python
-*.pyc
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Python distribution/packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
 
 # Jupyter
 *.ipynb

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# syntax=docker/dockerfile:1
+ARG PYTHON_VERSION=3.10.16
+FROM python:${PYTHON_VERSION}-slim as base
+
+RUN apt-get update -y && apt-get install -y \
+    git \
+ && rm -rf /var/lib/apt/lists/*
+
+# Prevent Python from writing pyc files.
+ENV PYTHONDONTWRITEBYTECODE=1
+
+# Keep Python from buffering stdout and stderr to avoid situations where
+# the application crashes without emitting any logs due to buffering.
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# Create a non-privileged user
+ARG UID=10001
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "/nonexistent" \
+    --no-create-home \
+    --shell "/sbin/nologin" \
+    --uid "${UID}" \
+    mainuser
+
+# Download dependencies as a separate step to take advantage of Docker's caching.
+# Leverage a cache mount to /root/.cache/pip to speed up subsequent builds.
+# Leverage a bind mount to requirements.txt to avoid having to copy them into
+# into this layer.
+RUN --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=bind,source=requirements/,target=requirements/ \
+    python -m pip install -r requirements/local.txt
+
+# Switch to the non-privileged user.
+USER mainuser
+
+# Copy the source code into the container.
+COPY . .
+
+# Expose the port that the application listens on.
+EXPOSE 8000
+
+# Run the application.
+CMD python project/manage.py runserver 0.0.0.0:8000

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,46 @@
+---
+name: coralnet
+
+services:
+  server:
+    build:
+      context: .
+    ports:
+      - 8000:8000
+    environment:
+      - CORALNET_SETTINGS_BASE=${SETTINGS_BASE}
+      - CORALNET_DATABASE_NAME=${DATABASE_NAME}
+      - CORALNET_DATABASE_USER=${DATABASE_USER}
+      - CORALNET_DATABASE_PASSWORD=${DATABASE_PASSWORD}
+      - CORALNET_SECRET_KEY=${SECRET_KEY}
+      - CORALNET_DATABASE_HOST=db         # Name of the `db` container below
+    tmpfs:
+      - /log/:exec,mode=777
+    develop:
+      watch:
+        - action: rebuild
+          path: .
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: postgres
+    restart: always
+    user: postgres
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_USER=${DATABASE_USER}
+      - POSTGRES_DB=${DATABASE_NAME}
+      - POSTGRES_PASSWORD=${DATABASE_PASSWORD}
+    expose:
+      - 5432
+    healthcheck:
+      test: ["CMD", "pg_isready"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  db-data:


### PR DESCRIPTION
This PR adds a `Dockerfile` and `compose.yaml` file to allow CoralNet to be run in a Docker container without having to setup Python locally. I followed the manual instructions from Docker's ['Use containers for Python development' page](https://docs.docker.com/guides/python/develop/), which includes updating the `.gitignore` file and adding a `.dockerignore` file.

## Usage
To run CoralNet while watching for changes in the project files:

```shell
docker compose watch
```

Then connect to [localhost:8000](http://localhost:8000/) to access the local instance of CoralNet.

## Preparation
To start using this Docker image for the first time:

1. Create a `.env` file following the [installation instructions](https://github.com/coralnet/coralnet/blob/main/docs/installation.rst#settings).
2. Start the Docker containers:
    ```shell
    docker compose watch
    ```
4. If you get the warning `You have 132 unapplied migration(s)`, initialize the new database:
    ```shell
    docker exec -ti coralnet-server-1 \
      python project/manage.py migrate
    ```
5. Optionally, create a superuser account to access CoralNet:
    ```shell
    docker exec -ti coralnet-server-1 \
      python project/manage.py createsuperuser
    ```
    This will ask for a username and password.
6. Connect to [localhost:8000](http://localhost:8000/) to access the local instance of CoralNet.