### PR TITLE
Fix api_core migration 0013

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ For info about the semantic versioning used here, see `docs/versions.rst`.
 "Production:" dates under each version indicate when the production server was updated to that version.
 
 
+## 1.19.1 (WIP)
+
+- Migration 0013 for `api_core` has been fixed, so that finished API jobs with one or more failed units still get finish dates like they're supposed to. To update from 1.19, unapply and then reapply migration 0013.
+
 ## [1.19](https://github.com/coralnet/coralnet/tree/1.19)
 
 Production: 2025-02-20

--- a/project/api_core/migrations/0013_apijob_finish_date_populate.py
+++ b/project/api_core/migrations/0013_apijob_finish_date_populate.py
@@ -7,8 +7,10 @@ def populate(apps, schema_editor):
     ApiJob = apps.get_model('api_core', 'ApiJob')
 
     for api_job in ApiJob.objects.all():
-        units = api_job.apijobunit_set.all()
-        if not units.filter(result_json__isnull=True).exists():
+        units = api_job.apijobunit_set
+        unfinished_units = units.filter(
+            internal_job__status__in=['pending', 'in_progress'])
+        if not unfinished_units.exists():
             api_job.finish_date = units.order_by(
                 '-internal_job__modify_date').first().internal_job.modify_date
             api_job.save()


### PR DESCRIPTION
Now finished API jobs with one or more failed units should still get finish dates like they're supposed to.

Had gotten unnecessarily cute with the check for finished units in the migration, and it didn't pay off.