### PR TITLE
Fix ApiJob finish_date setting logic

### DIFF
--- a/project/api_core/models.py
+++ b/project/api_core/models.py
@@ -142,17 +142,6 @@ class ApiJobUnit(models.Model):
                 fields=['parent', 'order_in_parent']),
         ]
 
-    def save(self, *args, **kwargs):
-        super().save(*args, **kwargs)
-
-        if self.result_json:
-            # Finished this unit.
-            incomplete_units = self.parent.apijobunit_set.filter(result_json__isnull=True)
-            if not incomplete_units.exists():
-                # All other units have finished too.
-                self.parent.finish_date = self.modify_date
-                self.parent.save()
-
 
 class UserApiLimits(models.Model):
     """


### PR DESCRIPTION
Like in PR #601, wrongly assumed result_json was set for failure units.

I also forgot that, at the time of ApiJobUnit.save(), the internal_job would not have had its status updated yet. So I needed to use an after_finishing_job hook instead.