### PR TITLE
collect_spacer_jobs optimizations

### DIFF
--- a/project/annotations/tests/test_delete.py
+++ b/project/annotations/tests/test_delete.py
@@ -5,8 +5,7 @@ from django.urls import reverse
 
 from jobs.tasks import run_scheduled_jobs_until_empty
 from lib.tests.utils import BasePermissionTest, ClientTest, spy_decorator
-from vision_backend.tests.tasks.utils import (
-    BaseTaskTest, do_collect_spacer_jobs)
+from vision_backend.tests.tasks.utils import BaseTaskTest
 from visualization.tests.utils import (
     BrowseActionsFormTest, BROWSE_IMAGES_DEFAULT_SEARCH_PARAMS)
 from ..managers import AnnotationQuerySet
@@ -236,7 +235,7 @@ class ClassifyAfterDeleteTest(BaseTaskTest):
             image_options=dict(filename='unconfirmed.png'))
         # Extract features
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
         # Classify
         run_scheduled_jobs_until_empty()
 

--- a/project/api_core/tests/test_views.py
+++ b/project/api_core/tests/test_views.py
@@ -8,7 +8,6 @@ from django.urls import reverse
 from rest_framework import status
 
 from lib.tests.utils import ClientTest
-from vision_backend.tests.tasks.utils import do_collect_spacer_jobs
 from vision_backend_api.tests.utils import DeployBaseTest
 from ..models import ApiJob, UserApiLimits
 from .utils import APITestMixin, BaseAPIPermissionTest
@@ -359,7 +358,7 @@ class UserShowContentTest(DeployBaseTest):
 
     def complete_api_jobs(self):
         self.run_scheduled_jobs_including_deploy()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
 
     def test_no_jobs(self):
         self.assertDictEqual(
@@ -491,7 +490,7 @@ class UserShowQueriesTest(DeployBaseTest):
 
     def complete_api_jobs(self):
         self.run_scheduled_jobs_including_deploy()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
 
     @override_settings(USER_DEFAULT_MAX_ACTIVE_API_JOBS=5)
     def test(self):

--- a/project/jobs/utils.py
+++ b/project/jobs/utils.py
@@ -246,6 +246,21 @@ def abort_job(job_id: int):
     finish_job(job, success=False, result_message="Aborted manually")
 
 
+def finish_jobs(jobs_details: list[dict]):
+    jobs = []
+
+    for job_details in jobs_details:
+        job = job_details['job']
+        job.result_message = job_details['result_message'] or ""
+        job.status = (
+            Job.Status.SUCCESS if job_details['success']
+            else Job.Status.FAILURE)
+        jobs.append(job)
+    Job.objects.bulk_update(jobs, ['result_message', 'status'])
+
+    # No periodic-job case. Periodic jobs should use finish_job() instead.
+
+
 class JobDecorator:
     def __init__(
         self, job_name: str = None, job_display_name: str = None,

--- a/project/lib/tests/utils.py
+++ b/project/lib/tests/utils.py
@@ -779,3 +779,26 @@ def spy_decorator(method_to_decorate):
         return method_to_decorate(self, *args, **kwargs)
     wrapper.mock_obj = mock_obj
     return wrapper
+
+
+class DecoratorMock:
+    """
+    A way to mock a method with a version which runs code before
+    and/or after.
+    """
+    @classmethod
+    def get_mock(cls, method_to_decorate):
+        def wrapper(self, *args, **kwargs):
+            cls.before(self, *args, **kwargs)
+            result = method_to_decorate(self, *args, **kwargs)
+            cls.after(self, *args, **kwargs)
+            return result
+        return wrapper
+
+    @classmethod
+    def before(cls, obj, *args, **kwargs):
+        pass
+
+    @classmethod
+    def after(cls, obj, *args, **kwargs):
+        pass

--- a/project/sources/tests/test_source_main.py
+++ b/project/sources/tests/test_source_main.py
@@ -13,8 +13,7 @@ from lib.utils import date_display, datetime_display
 from newsfeed.models import NewsItem
 from vision_backend.common import Extractors
 from vision_backend.models import Classifier
-from vision_backend.tests.tasks.utils import (
-    BaseTaskTest, do_collect_spacer_jobs)
+from vision_backend.tests.tasks.utils import BaseTaskTest
 from vision_backend.utils import schedule_source_check
 from ..models import Source
 
@@ -294,7 +293,7 @@ class SourceMainBackendColumnTest(BaseTaskTest):
             schedule_source_check(self.source.pk)
             # Train
             run_scheduled_jobs_until_empty()
-            do_collect_spacer_jobs()
+            self.do_collect_spacer_jobs()
 
         classifier_2 = self.source.classifier_set.latest('pk')
         self.assertEqual(classifier_2.status, Classifier.REJECTED_ACCURACY)

--- a/project/vision_backend/queues.py
+++ b/project/vision_backend/queues.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 from io import BytesIO
 import json
 from logging import getLogger
-from typing import Optional, Type
+from typing import Type
 
 import boto3
 from botocore.exceptions import ClientError
@@ -15,7 +15,8 @@ from spacer.messages import JobMsg, JobReturnMsg
 from spacer.tasks import process_job
 
 from config.constants import SpacerJobSpec
-from jobs.utils import finish_job
+from jobs.models import Job
+from jobs.utils import finish_jobs
 from .models import BatchJob
 
 logger = getLogger(__name__)
@@ -32,7 +33,7 @@ class BaseQueue(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def collect_job(self, job) -> tuple[Optional[JobReturnMsg], str]:
+    def collect_jobs(self, jobs: list) -> tuple[list[JobReturnMsg], list[str]]:
         raise NotImplementedError
 
 
@@ -91,12 +92,23 @@ class BatchQueue(BaseQueue):
         batch_job.save()
 
     @staticmethod
-    def handle_job_failure(batch_job, error_message):
-        batch_job.status = 'FAILED'
-        batch_job.save()
+    def handle_job_failures(failures):
+        if not failures:
+            return
 
-        finish_job(
-            batch_job.internal_job, success=False, result_message=error_message)
+        internal_jobs_by_id = Job.objects.in_bulk(
+            [batch_job.internal_job_id for batch_job, _ in failures])
+
+        finish_jobs_args = []
+        for batch_job, error_message in failures:
+            batch_job.status = 'FAILED'
+            finish_jobs_args.append(dict(
+                job=internal_jobs_by_id[batch_job.internal_job_id],
+                success=False,
+                result_message=error_message,
+            ))
+
+        finish_jobs(finish_jobs_args)
 
     def get_collectable_jobs(self):
         # Not-yet-collected BatchJobs.
@@ -106,39 +118,22 @@ class BatchQueue(BaseQueue):
             .order_by('pk')
         )
 
-    def collect_job(self, job: BatchJob) -> tuple[Optional[JobReturnMsg], str]:
-        if job.batch_token is None:
-            # Didn't get a batch token from AWS Batch. May indicate AWS
-            # service problems (see coralnet issue 458) or it may just be
-            # unlucky timing between submit and collect. Check the
-            # create_date to be sure.
-            if timezone.now() - job.create_date > timedelta(minutes=30):
-                # Likely an AWS service problem.
-                self.handle_job_failure(
-                    job, "Failed to get AWS Batch token.")
-                return None, 'DROPPED'
-            else:
-                # Let's wait a bit longer.
-                return None, 'NOT SUBMITTED'
+    @staticmethod
+    def process_response_for_job(job, response_for_job):
 
-        resp = self.batch_client.describe_jobs(jobs=[job.batch_token])
-
-        if len(resp['jobs']) == 0:
-            self.handle_job_failure(
-                job, f"Batch job [{job}] not found in AWS.")
-            return None, 'DROPPED'
-
-        job.status = resp['jobs'][0]['status']
-        job.save()
+        job.status = response_for_job['status']
 
         if job.status == 'FAILED':
-            self.handle_job_failure(
-                job, f"Batch job [{job}] marked as FAILED by AWS.")
-            return None, job.status
+            return dict(
+                failure=(job, f"Batch job [{job}] marked as FAILED by AWS."),
+                status=job.status,
+            )
 
         if job.status != 'SUCCEEDED':
             # Not done yet, e.g. RUNNING
-            return None, job.status
+            return dict(
+                status=job.status,
+            )
 
         # Else: 'SUCCEEDED'
         job_res_loc = default_storage.spacer_data_loc(job.res_key)
@@ -147,15 +142,86 @@ class BatchQueue(BaseQueue):
             return_msg = JobReturnMsg.load(job_res_loc)
         except (ClientError, IOError) as e:
             # IOError for local storage, ClientError for S3 storage
-            self.handle_job_failure(
-                job,
-                f"Batch job [{job}] succeeded,"
-                f" but couldn't get output at the expected location."
-                f" ({e})")
-            return None, job.status
+            message = (
+                f"Batch job [{job}] succeeded, but couldn't get"
+                f" output at the expected location. ({e})"
+            )
+            return dict(
+                failure=(job, message),
+                status='FAILED',
+            )
 
-        # All went well
-        return return_msg, job.status
+        # All went well.
+        return dict(
+            result=return_msg,
+            status=job.status,
+        )
+
+    def collect_jobs(
+        self, jobs: list[BatchJob]
+    ) -> tuple[list[JobReturnMsg], list[str]]:
+
+        now = timezone.now()
+        failures = []
+        results = []
+        statuses = []
+        batch_tokens = []
+        job_ids_without_tokens = []
+
+        for job in jobs:
+            if job.batch_token:
+                batch_tokens.append(job.batch_token)
+            else:
+                # Didn't get a batch token from AWS Batch. May indicate AWS
+                # service problems (see coralnet issue 458) or it may just be
+                # unlucky timing between submit and collect. Check the
+                # create_date to be sure.
+                if now - job.create_date > timedelta(minutes=30):
+                    # Likely an AWS service problem.
+                    failures.append((
+                        job, "Failed to get AWS Batch token."))
+                    statuses.append('DROPPED')
+                else:
+                    # Let's wait a bit longer.
+                    statuses.append('NOT SUBMITTED')
+                job_ids_without_tokens.append(job.pk)
+
+        # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/batch/client/describe_jobs.html
+        # jobs is "A list of up to 100 job IDs."
+        boto_response = self.batch_client.describe_jobs(jobs=batch_tokens)
+
+        batch_tokens_to_responses = dict(
+            (response_job['jobId'], response_job)
+            for response_job in boto_response['jobs']
+        )
+
+        for job in jobs:
+
+            if job.pk in job_ids_without_tokens:
+                # Nothing more to do right now without a token.
+                continue
+
+            if job.batch_token not in batch_tokens_to_responses:
+                failures.append((
+                    job, f"Batch job [{job}] not found in AWS."))
+                statuses.append('DROPPED')
+                continue
+
+            response_for_job = batch_tokens_to_responses[job.batch_token]
+
+            d = self.process_response_for_job(job, response_for_job)
+            if 'failure' in d:
+                failures.append(d['failure'])
+            if 'status' in d:
+                statuses.append(d['status'])
+            if 'result' in d:
+                results.append(d['result'])
+
+        self.handle_job_failures(failures)
+
+        BatchJob.objects.bulk_update(jobs, ['status'])
+
+        return results, statuses
 
 
 class LocalQueue(BaseQueue):
@@ -186,16 +252,25 @@ class LocalQueue(BaseQueue):
         filenames.sort()
         return filenames
 
-    def collect_job(
-            self, job_filename: str) -> tuple[Optional[JobReturnMsg], str]:
+    def collect_jobs(
+        self, job_filenames: list[str]
+    ) -> tuple[list[JobReturnMsg], list[str]]:
 
-        # Read the job result message
-        filepath = default_storage.path_join('backend_job_res', job_filename)
-        with default_storage.open(filepath) as results_file:
-            return_msg = JobReturnMsg.deserialize(json.load(results_file))
-        # Delete the job result file
-        default_storage.delete(filepath)
+        results = []
+        statuses = []
 
-        # Unlike BatchQueue, LocalQueue is only aware of the
-        # jobs that successfully output their results.
-        return return_msg, 'SUCCEEDED'
+        for job_filename in job_filenames:
+            # Read the job result message
+            filepath = default_storage.path_join(
+                'backend_job_res', job_filename)
+            with default_storage.open(filepath) as results_file:
+                return_msg = JobReturnMsg.deserialize(json.load(results_file))
+            # Delete the job result file
+            default_storage.delete(filepath)
+
+            # Unlike BatchQueue, LocalQueue is only aware of the
+            # jobs that successfully output their results.
+            results.append(return_msg)
+            statuses.append('SUCCEEDED')
+
+        return results, statuses

--- a/project/vision_backend/queues.py
+++ b/project/vision_backend/queues.py
@@ -186,14 +186,17 @@ class BatchQueue(BaseQueue):
                     statuses.append('NOT SUBMITTED')
                 job_ids_without_tokens.append(job.pk)
 
-        # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/batch/client/describe_jobs.html
-        # jobs is "A list of up to 100 job IDs."
-        boto_response = self.batch_client.describe_jobs(jobs=batch_tokens)
+        if batch_tokens:
+            # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/batch/client/describe_jobs.html
+            # jobs is "A list of up to 100 job IDs."
+            boto_response = self.batch_client.describe_jobs(jobs=batch_tokens)
 
-        batch_tokens_to_responses = dict(
-            (response_job['jobId'], response_job)
-            for response_job in boto_response['jobs']
-        )
+            batch_tokens_to_responses = dict(
+                (response_job['jobId'], response_job)
+                for response_job in boto_response['jobs']
+            )
+        else:
+            batch_tokens_to_responses = dict()
 
         for job in jobs:
 

--- a/project/vision_backend/task_helpers.py
+++ b/project/vision_backend/task_helpers.py
@@ -1,8 +1,8 @@
 """
 This file contains helper functions to vision_backend.tasks.
 """
-from abc import ABC
-from collections import Counter
+import abc
+from collections import Counter, defaultdict
 from logging import getLogger
 import re
 
@@ -10,27 +10,28 @@ import numpy as np
 from django.conf import settings
 from django.core.mail import mail_admins
 from django.db import transaction
-from django.db.models import F
-from django.utils.timezone import now
+from django.db.models import Count, F, Q
+from django.utils import timezone
 from spacer.data_classes import ImageLabels
-from spacer.messages import \
-    ExtractFeaturesMsg, \
-    TrainClassifierMsg, \
-    ClassifyImageMsg, \
-    ClassifyReturnMsg, \
-    JobReturnMsg
+from spacer.messages import (
+    ClassifyImageMsg,
+    ClassifyReturnMsg,
+    ExtractFeaturesMsg,
+    JobReturnMsg,
+    TrainClassifierMsg,
+)
 
 from accounts.utils import get_robot_user
 from annotations.models import Annotation
-from api_core.models import ApiJobUnit
+from api_core.models import ApiJob, ApiJobUnit
 from errorlogs.utils import instantiate_error_log
 from images.models import Image, Point
 from jobs.exceptions import JobError
 from jobs.models import Job
-from jobs.utils import finish_job
-from labels.models import Label, LabelSet
+from jobs.utils import finish_jobs
+from labels.models import Label
 from .exceptions import RowColumnMismatchError
-from .models import Classifier, ClassifyImageEvent, Score
+from .models import Classifier, ClassifyImageEvent, Features, Score
 from .utils import (
     extractor_to_name,
     reset_invalid_features_bulk,
@@ -215,7 +216,7 @@ def make_dataset(images: list[Image]) -> ImageLabels:
     return ImageLabels(data)
 
 
-class SpacerResultHandler(ABC):
+class SpacerResultHandler(abc.ABC):
     """
     Each type of collectable spacer job should define a subclass
     of this base class.
@@ -228,95 +229,132 @@ class SpacerResultHandler(ABC):
     # rather than errors demanding attention of coralnet / pyspacer devs.
     non_priority_error_classes = []
 
-    @classmethod
-    def handle(cls, job_res: JobReturnMsg):
-        if not job_res.ok:
-            # Spacer got an uncaught error.
-            error_traceback = job_res.error_message
-            # Last line of the traceback should serve as a decent
-            # one-line summary. Has the error class and message.
-            error_message = error_traceback.splitlines()[-1]
-            # The error message should be either like:
-            # 1) `somemodule.SomeError: some error info`.
-            # We extract the error class/info as the part before/after
-            # the first colon.
-            # 2) `AssertionError`. Just a class, no colon, no detail.
-            if ':' in error_message:
-                error_class, error_info = error_message.split(':', maxsplit=1)
-                error_info = error_info.strip()
+    def handle_job_results(self, job_results: list[JobReturnMsg]):
+        """
+        The job_results must all have the same task name.
+        """
+        spacer_task_results = []
+
+        for job_res in job_results:
+            if not job_res.ok:
+                spacer_error = self.handle_job_result_error(job_res)
             else:
-                error_class = error_message
-                error_info = ""
+                spacer_error = None
 
-            if error_class not in cls.non_priority_error_classes:
-                # Priority error; treat like an internal server error.
+            # CoralNet currently only submits spacer jobs containing a single
+            # task.
+            task = job_res.original_job.tasks[0]
+            spacer_task_results.append(dict(
+                task=task,
+                job_res=job_res,
+                spacer_error=spacer_error,
+            ))
 
-                job_res_repr = repr(job_res)
-                if len(job_res_repr) > settings.EMAIL_SIZE_SOFT_LIMIT:
-                    job_res_repr = (
-                        job_res_repr[:settings.EMAIL_SIZE_SOFT_LIMIT]
-                        + " ...(truncated)"
-                    )
+        self.jobs_by_id = self.get_internal_jobs(
+            [result['task'] for result in spacer_task_results])
 
-                mail_admins(
-                    f"Spacer job failed: {cls.job_name}",
-                    job_res_repr,
-                )
+        self.handle_spacer_task_results(spacer_task_results)
 
-                # Just the class name, not the whole dotted path.
-                error_class_name = error_class.split('.')[-1]
-
-                error_html = f'<pre>{error_traceback}</pre>'
-                error_log = instantiate_error_log(
-                    kind=error_class_name,
-                    html=error_html,
-                    path=f"Spacer - {cls.job_name}",
-                    info=error_info,
-                    data=job_res_repr,
-                )
-                error_log.save()
-
-            spacer_error = error_class, error_message
+    @classmethod
+    def handle_job_result_error(cls, job_res):
+        # Spacer got an uncaught error.
+        error_traceback = job_res.error_message
+        # Last line of the traceback should serve as a decent
+        # one-line summary. Has the error class and message.
+        error_message = error_traceback.splitlines()[-1]
+        # The error message should be either like:
+        # 1) `somemodule.SomeError: some error info`.
+        # We extract the error class/info as the part before/after
+        # the first colon.
+        # 2) `AssertionError`. Just a class, no colon, no detail.
+        if ':' in error_message:
+            error_class, error_info = error_message.split(':', maxsplit=1)
+            error_info = error_info.strip()
         else:
-            spacer_error = None
+            error_class = error_message
+            error_info = ""
 
-        # CoralNet currently only submits spacer jobs containing a single
-        # task.
-        task = job_res.original_job.tasks[0]
+        if error_class not in cls.non_priority_error_classes:
+            # Priority error; treat like an internal server error.
 
-        success = False
-        result_message = None
-        try:
-            result_message = cls.handle_spacer_task_result(
-                task, job_res, spacer_error)
-            success = True
-        except JobError as e:
-            result_message = str(e)
-        finally:
-            internal_job_id = task.job_token
+            job_res_repr = repr(job_res)
+            if len(job_res_repr) > settings.EMAIL_SIZE_SOFT_LIMIT:
+                job_res_repr = (
+                    job_res_repr[:settings.EMAIL_SIZE_SOFT_LIMIT]
+                    + " ...(truncated)"
+                )
 
-            job = Job.objects.get(pk=internal_job_id)
-            finish_job(job, success=success, result_message=result_message)
+            mail_admins(
+                f"Spacer job failed: {cls.job_name}",
+                job_res_repr,
+            )
 
-            cls.after_finishing_job(job.pk)
+            # Just the class name, not the whole dotted path.
+            error_class_name = error_class.split('.')[-1]
+
+            error_html = f'<pre>{error_traceback}</pre>'
+            error_log = instantiate_error_log(
+                kind=error_class_name,
+                html=error_html,
+                path=f"Spacer - {cls.job_name}",
+                info=error_info,
+                data=job_res_repr,
+            )
+            error_log.save()
+
+        return error_class, error_message
+
+    @staticmethod
+    def get_internal_job_id(spacer_task):
+        return int(spacer_task.job_token)
 
     @classmethod
-    def after_finishing_job(cls, job_id):
-        pass
+    def get_internal_jobs(cls, spacer_tasks):
+        job_ids = [cls.get_internal_job_id(task) for task in spacer_tasks]
+        jobs_by_id = Job.objects.in_bulk(job_ids)
+        return jobs_by_id
 
-    @classmethod
-    def get_internal_job(cls, task):
-        internal_job_id = task.job_token
-        try:
-            return Job.objects.get(pk=internal_job_id)
-        except Job.DoesNotExist:
-            raise JobError(f"Job {internal_job_id} doesn't exist anymore.")
+    @abc.abstractmethod
+    def handle_spacer_task_results(self, spacer_task_results: list[dict]):
+        raise NotImplementedError
+
+    def handle_task_results_main_loop(self, spacer_task_results):
+        finish_jobs_args = []
+
+        for spacer_task_result in spacer_task_results:
+            task = spacer_task_result['task']
+            success = False
+            result_message = None
+
+            job_id = self.get_internal_job_id(task)
+            try:
+                job = self.jobs_by_id[job_id]
+            except KeyError:
+                # Job doesn't exist anymore. There shouldn't be anything
+                # else to do regarding this result.
+                continue
+
+            try:
+                result_message = self.handle_spacer_task_result(
+                    **spacer_task_result)
+                success = True
+            except JobError as e:
+                result_message = str(e)
+            finally:
+                finish_jobs_args.append(dict(
+                    job=job,
+                    success=success,
+                    result_message=result_message,
+                ))
+
+        finish_jobs(finish_jobs_args)
 
     @classmethod
     def handle_spacer_task_result(cls, task, job_res, spacer_error):
         """
         Handles the result of a spacer task (a sub-unit within a spacer job)
         and raises a JobError if an error is found.
+        Optionally returns a string result-message.
         """
         raise NotImplementedError
 
@@ -333,19 +371,50 @@ class SpacerFeatureResultHandler(SpacerResultHandler):
         'spacer.exceptions.RowColumnMismatchError',
     ]
 
-    @classmethod
+    def handle_spacer_task_results(self, spacer_task_results: list[dict]):
+        jobs = list(self.jobs_by_id.values())
+        image_ids = [int(job.arg_identifier) for job in jobs]
+
+        self.images_by_id = Image.objects.in_bulk(image_ids)
+        self.features_by_image_id = Features.objects.in_bulk(
+            image_ids, field_name='image_id')
+        self.now = timezone.now()
+        # TODO: Retrieving points and feature-extractor settings for all
+        #  images in bulk here could result in more DB optimization.
+
+        self.handle_task_results_main_loop(spacer_task_results)
+
+        features = list(self.features_by_image_id.values())
+        Features.objects.bulk_update(
+            features,
+            ['extracted', 'extractor', 'runtime_total',
+             'extractor_loaded_remotely', 'extracted_date', 'has_rowcols'],
+        )
+
+        source_ids = set(job.source_id for job in jobs)
+        for source_id in source_ids:
+            if source_is_finished_with_core_jobs(source_id):
+                # If not waiting for other 'core' jobs,
+                # check if the source has any next steps.
+                schedule_source_check(source_id)
+
     def handle_spacer_task_result(
-            cls,
+            self,
             task: ExtractFeaturesMsg,
             job_res: JobReturnMsg,
             spacer_error: tuple[str, str] | None) -> None:
 
-        internal_job = cls.get_internal_job(task)
-        image_id = internal_job.arg_identifier
+        internal_job = self.jobs_by_id[self.get_internal_job_id(task)]
+        image_id = int(internal_job.arg_identifier)
+
         try:
-            img = Image.objects.get(pk=image_id)
-        except Image.DoesNotExist:
+            image = self.images_by_id[image_id]
+        except KeyError:
             raise JobError(f"Image {image_id} doesn't exist anymore.")
+
+        # This should always exist, so we'll let it be an uncaught
+        # exception if it's missing.
+        features = self.features_by_image_id[image_id]
 
         if spacer_error:
             # Error from spacer when running the spacer job.
@@ -356,37 +425,30 @@ class SpacerFeatureResultHandler(SpacerResultHandler):
         task_res = job_res.results[0]
 
         # Check that the row-col information hasn't changed.
-        rowcols = [(p.row, p.column) for p in Point.objects.filter(image=img)]
+        rowcols = [
+            (p['row'], p['column']) for p
+            in image.point_set.values('row', 'column')]
         if not set(rowcols) == set(task.rowcols):
             raise JobError(
-                f"Row-col data for {img} has changed"
+                f"Row-col data for {image} has changed"
                 f" since this task was submitted.")
 
         # Check that the active feature-extractor hasn't changed.
         task_extractor = extractor_to_name(task.extractor)
-        if task_extractor != img.source.feature_extractor:
+        if task_extractor != image.source.feature_extractor:
             raise JobError(
                 f"Feature extractor selection has changed"
                 f" since this task was submitted.")
 
         # If all is ok store meta-data.
-        img.features.extracted = True
-        img.features.extractor = task_extractor
-        img.features.runtime_total = task_res.runtime
+        features.extracted = True
+        features.extractor = task_extractor
+        features.runtime_total = task_res.runtime
 
-        img.features.extractor_loaded_remotely = \
+        features.extractor_loaded_remotely = \
             task_res.extractor_loaded_remotely
-        img.features.extracted_date = now()
-        img.features.has_rowcols = True
-        img.features.save()
-
-    @classmethod
-    def after_finishing_job(cls, job_id):
-        job = Job.objects.get(pk=job_id)
-        if source_is_finished_with_core_jobs(job.source_id):
-            # If not waiting for other 'core' jobs,
-            # check if the source has any next steps.
-            schedule_source_check(job.source_id)
+        features.extracted_date = self.now
+        features.has_rowcols = True
 
 
 class SpacerTrainResultHandler(SpacerResultHandler):
@@ -400,6 +462,26 @@ class SpacerTrainResultHandler(SpacerResultHandler):
         # shouldn't be needed.
         'spacer.exceptions.RowColumnMismatchError',
     ]
+
+    def handle_spacer_task_results(self, spacer_task_results: list[dict]):
+        """
+        This delegates almost everything to the main loop because we don't
+        expect to batch many training jobs together, and thus bulk actions
+        won't help much.
+        """
+        self.handle_task_results_main_loop(spacer_task_results)
+
+        for job in self.jobs_by_id.values():
+            # Successful jobs related to classifier history should persist
+            # in the DB.
+            if job.status == Job.Status.SUCCESS:
+                job.persist = True
+                job.save()
+
+            if source_is_finished_with_core_jobs(job.source_id):
+                # If not waiting for other 'core' jobs,
+                # check if the source has any next steps.
+                schedule_source_check(job.source_id)
 
     @classmethod
     def handle_spacer_task_result(
@@ -515,21 +597,6 @@ class SpacerTrainResultHandler(SpacerResultHandler):
 
         return f"New classifier accepted: {classifier.pk}"
 
-    @classmethod
-    def after_finishing_job(cls, job_id):
-        job = Job.objects.get(pk=job_id)
-
-        # Successful jobs related to classifier history should persist
-        # in the DB.
-        if job.status == Job.Status.SUCCESS:
-            job.persist = True
-            job.save()
-
-        if source_is_finished_with_core_jobs(job.source_id):
-            # If not waiting for other 'core' jobs,
-            # check if the source has any next steps.
-            schedule_source_check(job.source_id)
-
 
 class SpacerClassifyResultHandler(SpacerResultHandler):
     job_name = 'classify_image'
@@ -556,19 +623,72 @@ class SpacerClassifyResultHandler(SpacerResultHandler):
         'spacer.exceptions.URLDownloadError',
     ]
 
-    @classmethod
+    @staticmethod
+    def get_classifier_labelset(classifier_id):
+        classifier = Classifier.objects.get(pk=classifier_id)
+        labelset = classifier.source.labelset
+        labels_values = list(labelset.locallabel_set.values(
+            'global_label_id',
+            'global_label__name',
+            'code',
+        ))
+        return {
+            label_values['global_label_id']: label_values
+            for label_values in labels_values
+        }
+
+    def handle_spacer_task_results(self, spacer_task_results: list[dict]):
+        job_ids = list(self.jobs_by_id.keys())
+        self.job_units_by_job_id = ApiJobUnit.objects.in_bulk(
+            job_ids, field_name='internal_job_id')
+        self.labelsets_by_classifier = dict()
+
+        self.handle_task_results_main_loop(spacer_task_results)
+
+        job_units = list(self.job_units_by_job_id.values())
+        ApiJobUnit.objects.bulk_update(job_units, ['result_json'])
+
+        api_jobs = (
+            ApiJob.objects
+            .filter(apijobunit__in=[unit.pk for unit in job_units])
+            .annotate(
+                pending_units=Count(
+                    'apijobunit',
+                    filter=Q(
+                        apijobunit__internal_job__status
+                        =Job.Status.PENDING)),
+                in_progress_units=Count(
+                    'apijobunit',
+                    filter=Q(
+                        apijobunit__internal_job__status
+                        =Job.Status.IN_PROGRESS)),
+            )
+        )
+        api_jobs_to_update = []
+        for api_job in api_jobs:
+            if (
+                api_job.pending_units == 0
+                and api_job.in_progress_units == 0
+                and not api_job.finish_date
+            ):
+                # All other units of the API job have finished too.
+                api_job.finish_date = timezone.now()
+                api_jobs_to_update.append(api_job)
+        ApiJob.objects.bulk_update(api_jobs_to_update, ['finish_date'])
+
     def handle_spacer_task_result(
-            cls,
+            self,
             task: ClassifyImageMsg,
             job_res: JobReturnMsg,
             spacer_error: tuple[str, str] | None) -> None:
 
-        internal_job = cls.get_internal_job(task)
+        job_id = self.get_internal_job_id(task)
+
         try:
-            job_unit = ApiJobUnit.objects.get(internal_job=internal_job)
-        except ApiJobUnit.DoesNotExist:
+            job_unit = self.job_units_by_job_id[job_id]
+        except KeyError:
             raise JobError(
-                f"API job unit for internal-job {internal_job.pk}"
+                f"API job unit for internal-job {job_id}"
                 f" does not exist.")
 
         if spacer_error:
@@ -580,19 +700,23 @@ class SpacerClassifyResultHandler(SpacerResultHandler):
         task_res = job_res.results[0]
 
         classifier_id = job_unit.request_json['classifier_id']
-        try:
-            classifier = Classifier.objects.get(pk=classifier_id)
-        except Classifier.DoesNotExist:
-            raise JobError(f"Classifier of id {classifier_id} does not exist.")
+        if classifier_id not in self.labelsets_by_classifier:
+            try:
+                self.labelsets_by_classifier[classifier_id] = (
+                    self.get_classifier_labelset(classifier_id))
+            except Classifier.DoesNotExist:
+                raise JobError(
+                    f"Classifier of id {classifier_id} does not exist.")
 
         job_unit.result_json = dict(
             url=job_unit.request_json['url'],
-            points=cls.build_points_dicts(task_res, classifier.source.labelset)
+            points=self.build_points_dicts(
+                task_res, self.labelsets_by_classifier[classifier_id]),
         )
-        job_unit.save()
 
     @staticmethod
-    def build_points_dicts(res: ClassifyReturnMsg, labelset: LabelSet):
+    def build_points_dicts(
+            res: ClassifyReturnMsg, labels: dict[int, dict]):
         """
         Converts scores from the deploy call to the dictionary returned
         by the API
@@ -602,46 +726,28 @@ class SpacerClassifyResultHandler(SpacerResultHandler):
         nbr_scores = min(settings.NBR_SCORES_PER_ANNOTATION,
                          len(res.classes))
 
-        # Pre-fetch label objects. The local labels let us reach all the
-        # fields we want.
-        local_labels = []
-        for class_ in res.classes:
-            local_label = labelset.locallabel_set.get(global_label__pk=class_)
-            local_labels.append(local_label)
+        classes_info = [
+            labels[global_label_id]
+            for global_label_id in res.classes
+        ]
 
         data = []
         for row, col, scores in res.scores:
-            # grab the index of the highest indices
-            inds = np.argsort(scores)[::-1][:nbr_scores]
+            # Grab the indices of the highest-scoring labels.
+            best_scoring_indices = np.argsort(scores)[::-1][:nbr_scores]
             classifications = []
-            for ind in inds:
-                local_label = local_labels[ind]
+            for ind in best_scoring_indices:
+                class_info = classes_info[ind]
                 classifications.append(dict(
-                    label_id=local_label.global_label.pk,
-                    label_name=local_label.global_label.name,
-                    label_code=local_label.code,
-                    score=scores[ind]))
-            data.append(dict(row=row,
-                             column=col,
-                             classifications=classifications
-                             )
-                        )
+                    label_id=class_info['global_label_id'],
+                    label_name=class_info['global_label__name'],
+                    label_code=class_info['code'],
+                    score=scores[ind],
+                ))
+            data.append(dict(
+                row=row, column=col, classifications=classifications,
+            ))
         return data
-
-    @classmethod
-    def after_finishing_job(cls, job_id):
-        job = Job.objects.get(pk=job_id)
-
-        if job.status in [Job.Status.SUCCESS, Job.Status.FAILURE]:
-            # Finished this API job unit.
-            api_job = job.apijobunit.parent
-            unfinished_units = api_job.apijobunit_set.filter(
-                internal_job__status__in=[
-                    Job.Status.PENDING, Job.Status.IN_PROGRESS])
-            if not unfinished_units.exists():
-                # All other units of the API job have finished too.
-                api_job.finish_date = job.modify_date
-                api_job.save()
 
 
 handler_classes = [
@@ -651,12 +757,20 @@ handler_classes = [
 ]
 
 
-def handle_spacer_result(job_res: JobReturnMsg):
-    """Handles the job results found in queue. """
+def handle_spacer_results(job_results: list[JobReturnMsg]):
+    task_names_to_handler_classes = dict(
+        (handler_class.job_name, handler_class)
+        for handler_class in handler_classes
+    )
 
-    task_name = job_res.original_job.task_name
-    for HandlerClass in handler_classes:
-        if task_name == HandlerClass.job_name:
-            HandlerClass.handle(job_res)
-            return
-    logger.error(f"Spacer task name [{task_name}] not recognized")
+    job_results_by_task_name = defaultdict(list)
+    for job_res in job_results:
+        job_results_by_task_name[
+            job_res.original_job.task_name].append(job_res)
+
+    for task_name, task_name_job_results in job_results_by_task_name.items():
+        if task_name in task_names_to_handler_classes:
+            handler_class = task_names_to_handler_classes[task_name]
+            handler_class().handle_job_results(task_name_job_results)
+        else:
+            logger.error(f"Spacer task name [{task_name}] not recognized")

--- a/project/vision_backend/tests/tasks/test_classify.py
+++ b/project/vision_backend/tests/tasks/test_classify.py
@@ -22,8 +22,7 @@ from ...common import Extractors
 from ...exceptions import RowColumnMismatchError
 from ...models import Classifier, ClassifyImageEvent, Score
 from ...utils import clear_features
-from .utils import (
-    BaseTaskTest, do_collect_spacer_jobs, source_check_is_scheduled)
+from .utils import BaseTaskTest, source_check_is_scheduled
 
 
 def noop(*args, **kwargs):
@@ -139,7 +138,7 @@ class SourceCheckTest(BaseTaskTest):
         image = self.upload_image(self.user, other_source)
         # Extract features
         do_job('extract_features', image.pk, source_id=other_source.pk)
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
 
         self.assertIsNone(other_source.last_accepted_classifier)
         self.source_check_and_assert(
@@ -609,7 +608,7 @@ class ClassifyImageTest(BaseTaskTest, AnnotationHistoryTestMixin):
         self.add_annotations(self.user, img, {1: 'A'})
         # Extract features
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
         # Classify
         run_scheduled_jobs_until_empty()
 
@@ -650,7 +649,7 @@ class ClassifyImageTest(BaseTaskTest, AnnotationHistoryTestMixin):
         img = self.upload_image_with_annotations('confirmed.png')
         # Extract features
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
         # Attempt to classify
         run_scheduled_jobs_until_empty()
 
@@ -731,7 +730,7 @@ class ClassifyImageTest(BaseTaskTest, AnnotationHistoryTestMixin):
         image = self.upload_image(self.user, other_source)
         # Extract features
         do_job('extract_features', image.pk, source_id=other_source.pk)
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
         # Classify image
         do_job('classify_features', image.pk, source_id=other_source.pk)
         image.refresh_from_db()
@@ -754,10 +753,10 @@ class ClassifyImageTest(BaseTaskTest, AnnotationHistoryTestMixin):
         img = self.upload_image_with_dupe_points('has_dupe.png')
         # Extract features
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
         # Train
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
         # Classify
         run_scheduled_jobs_until_empty()
 

--- a/project/vision_backend/tests/tasks/test_misc.py
+++ b/project/vision_backend/tests/tasks/test_misc.py
@@ -1,6 +1,8 @@
+import json
 from unittest import mock
 
 from django.test.utils import override_settings
+from django.urls import reverse
 
 from annotations.managers import AnnotationQuerySet
 from annotations.models import Annotation
@@ -9,6 +11,7 @@ from jobs.tasks import run_scheduled_jobs, run_scheduled_jobs_until_empty
 from jobs.tests.utils import do_job, fabricate_job
 from jobs.utils import abort_job, schedule_job
 from lib.tests.utils import spy_decorator
+from vision_backend_api.tests.utils import DeployTestMixin
 from ...models import Score, Classifier
 from .utils import (
     BaseTaskTest, do_collect_spacer_jobs, source_check_is_scheduled)
@@ -284,7 +287,6 @@ def schedule_collect_spacer_jobs():
     return Queue
 
 
-@override_settings(ENABLE_PERIODIC_JOBS=False)
 class CollectSpacerJobsTest(BaseTaskTest):
 
     def test_success(self):
@@ -310,23 +312,34 @@ class CollectSpacerJobsTest(BaseTaskTest):
 
     @override_settings(JOB_MAX_MINUTES=-1)
     def test_time_out(self):
-        # Run 2 extract-features jobs.
-        self.upload_image(self.user, self.source)
-        self.upload_image(self.user, self.source)
+        # Run 6 extract-features jobs.
+        for _ in range(6):
+            self.upload_image(self.user, self.source)
         run_scheduled_jobs_until_empty()
 
-        # Collect jobs; this should time out after collecting 1st job and
-        # before collecting 2nd job (as that's when the 1st time-check is done)
-        self.assertEqual(
-            do_collect_spacer_jobs().result_message,
-            "Jobs checked/collected: 1 SUCCEEDED (timed out)")
+        def mock_batcher(items, batch_size):
+            # Force a batch size of 3 so that we don't have to create too
+            # many jobs for this test.
+            batch_size = 3
+            index = 0
+            while index < len(items):
+                yield items[index:index+batch_size]
+                index += batch_size
 
-        # Running again should collect the other job. It'll still say
+        # Collect jobs, with batch_generator() mocked to have batch size 3.
+        # This should time out after collecting 1st job and before
+        # collecting 4th job (as that's when the 1st time-check is done)
+        with mock.patch('vision_backend.tasks.batch_generator', mock_batcher):
+            self.assertEqual(
+                do_collect_spacer_jobs().result_message,
+                "Jobs checked/collected: 3 SUCCEEDED (timed out)")
+
+        # Running again should collect the other jobs. It'll still say
         # timed out because it didn't get a chance to check if there were
         # more jobs before timing out.
         self.assertEqual(
             do_collect_spacer_jobs().result_message,
-            "Jobs checked/collected: 1 SUCCEEDED (timed out)")
+            "Jobs checked/collected: 3 SUCCEEDED (timed out)")
 
         # Should be no more to collect.
         self.assertEqual(
@@ -348,3 +361,74 @@ class CollectSpacerJobsTest(BaseTaskTest):
         self.assertEqual(
             Job.objects.filter(job_name='collect_spacer_jobs').count(), 1,
             "Should not have accepted the second run")
+
+
+class CollectSpacerJobsMultipleTypesTest(BaseTaskTest, DeployTestMixin):
+
+    def test(self):
+        """
+        Should be able to handle a batch of jobs containing multiple
+        types of tasks.
+        """
+        user = self.create_user(
+            username='testuser', password='SamplePassword')
+
+        # source_1: set up to collect deploy API jobs.
+        source_1 = self.create_source(user)
+        self.create_labelset(user, source_1, self.labels)
+        classifier = self.upload_data_and_train_classifier(
+            source=source_1, user=user)
+        deploy_url = reverse('api:deploy', args=[classifier.pk])
+        deploy_request_kwargs = self.get_request_kwargs_for_user(
+            'testuser', 'SamplePassword')
+        # Come back to this source later.
+
+        # source_2: set up to collect training.
+        source_2 = self.create_source(user)
+        self.create_labelset(user, source_2, self.labels)
+        self.upload_images_for_training(source=source_2, user=user)
+        # Extract features.
+        run_scheduled_jobs_until_empty()
+        do_collect_spacer_jobs()
+        # Run training.
+        run_scheduled_jobs_until_empty()
+
+        # Back to source_1 to finish setting up. From here, don't run
+        # collect_spacer_jobs() again until all sources are set up.
+        images = [
+            dict(type='image', attributes=dict(
+                url='URL 1', points=[dict(row=10, column=10)]))]
+        data = json.dumps(dict(data=images))
+        # Schedule deploy.
+        self.client.post(deploy_url, data, **deploy_request_kwargs)
+        # Deploy.
+        self.run_scheduled_jobs_including_deploy()
+
+        # source_3: set up to collect feature extraction.
+        source_3 = self.create_source(user)
+        self.create_labelset(user, source_3, self.labels)
+        self.upload_image(user, source_3)
+        self.upload_image(user, source_3)
+        # Run feature extraction.
+        run_scheduled_jobs_until_empty()
+
+        # Ensure all that stuff hasn't been collected yet.
+        deploy_job = Job.objects.filter(
+            job_name='classify_image').latest('pk')
+        train_job = Job.objects.get(
+            job_name='train_classifier', source_id=source_2.pk)
+        extract_jobs = list(Job.objects.filter(
+            job_name='extract_features', source_id=source_3.pk))
+        self.assertEqual(len(extract_jobs), 2)
+        for job in [deploy_job, train_job] + extract_jobs:
+            self.assertEqual(job.status, Job.Status.IN_PROGRESS)
+
+        # Now collect.
+        do_collect_spacer_jobs()
+        # 1 deploy, 1 train, 2 extract
+        self.assert_job_result_message(
+            'collect_spacer_jobs', "Jobs checked/collected: 4 SUCCEEDED")
+        # Should all be done.
+        for job in [deploy_job, train_job] + extract_jobs:
+            job.refresh_from_db()
+            self.assertEqual(job.status, Job.Status.SUCCESS)

--- a/project/vision_backend/tests/tasks/test_train.py
+++ b/project/vision_backend/tests/tasks/test_train.py
@@ -19,7 +19,6 @@ from ...queues import get_queue_class
 from ...task_helpers import handle_spacer_results
 from .utils import (
     BaseTaskTest,
-    do_collect_spacer_jobs,
     ensure_source_check_not_scheduled,
     source_check_is_scheduled,
 )
@@ -44,7 +43,7 @@ class TrainClassifierTest(BaseTaskTest):
         # Provide enough data for training. Extract features.
         self.upload_images_for_training()
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
 
         self.assertTrue(
             source_check_is_scheduled(self.source.pk),
@@ -61,7 +60,7 @@ class TrainClassifierTest(BaseTaskTest):
         self.upload_images_for_training(
             train_image_count=3, val_image_count=val_image_count)
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
 
         # Train a classifier
         run_scheduled_jobs_until_empty()
@@ -80,7 +79,7 @@ class TrainClassifierTest(BaseTaskTest):
             ],
             runtime_custom=90,
         ):
-            do_collect_spacer_jobs()
+            self.do_collect_spacer_jobs()
 
         # Now we should have a trained classifier whose accuracy is the best so
         # far (due to having no previous classifiers), and thus it should have
@@ -142,12 +141,12 @@ class TrainClassifierTest(BaseTaskTest):
         # Provide enough data for training. Extract features.
         self.upload_images_for_training()
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
         # Submit classifier.
         run_scheduled_jobs_until_empty()
 
         # Collect classifier.
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
 
         clf_1 = self.source.last_accepted_classifier
 
@@ -156,7 +155,7 @@ class TrainClassifierTest(BaseTaskTest):
             train_image_count=2, val_image_count=0)
         # Extract features.
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
         # Submit classifier.
         run_scheduled_jobs_until_empty()
 
@@ -166,7 +165,7 @@ class TrainClassifierTest(BaseTaskTest):
             acc_custom=0.57,
             pc_accs_custom=[0.5],
         ):
-            do_collect_spacer_jobs()
+            self.do_collect_spacer_jobs()
 
         clf_2 = self.source.last_accepted_classifier
 
@@ -215,7 +214,7 @@ class TrainClassifierTest(BaseTaskTest):
 
         # Extract features.
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
         # Submit classifier.
         run_scheduled_jobs_until_empty()
 
@@ -228,14 +227,14 @@ class TrainClassifierTest(BaseTaskTest):
         # Provide enough data for training. Extract features.
         self.upload_images_for_training()
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
         # Submit classifier.
         run_scheduled_jobs_until_empty()
 
         self.assertFalse(source_check_is_scheduled(self.source.pk))
 
         # Collect classifier.
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
 
         self.assertTrue(
             source_check_is_scheduled(self.source.pk),
@@ -262,7 +261,7 @@ class TrainClassifierTest(BaseTaskTest):
 
         # Extract features
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
         # Train classifier; call internal job-collection methods to
         # get access to the job return msg.
         run_scheduled_jobs_until_empty()
@@ -321,9 +320,9 @@ class RetrainLogicTest(BaseTaskTest):
         # accepted during this class's tests.
         cls.upload_images_for_training(train_image_count=2, val_image_count=1)
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        cls.do_collect_spacer_jobs()
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        cls.do_collect_spacer_jobs()
         first_classifier = cls.source.last_accepted_classifier
         assert first_classifier.status == Classifier.ACCEPTED
 
@@ -331,13 +330,13 @@ class RetrainLogicTest(BaseTaskTest):
         # different 'previous classifier status' cases.
         cls.upload_images_for_training(train_image_count=1, val_image_count=0)
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        cls.do_collect_spacer_jobs()
         run_scheduled_jobs_until_empty()
         with mock_training_results(
             acc_custom=0.57,
             pc_accs_custom=[0.5],
         ):
-            do_collect_spacer_jobs()
+            cls.do_collect_spacer_jobs()
 
         cls.previous_classifier = cls.source.last_accepted_classifier
         assert cls.previous_classifier.status == Classifier.ACCEPTED
@@ -359,7 +358,7 @@ class RetrainLogicTest(BaseTaskTest):
 
         # Extract features.
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
         # Check source.
         run_scheduled_jobs()
         # Submit classifier.
@@ -453,7 +452,7 @@ class AbortCasesTest(BaseTaskTest, EmailAssertionsMixin, ErrorReportTestMixin):
         self.upload_images_for_training()
         # Extract features
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
 
         # Create a classifier in another source.
         other_source = self.create_source(self.user)
@@ -479,7 +478,7 @@ class AbortCasesTest(BaseTaskTest, EmailAssertionsMixin, ErrorReportTestMixin):
         # Prepare some training images + features.
         self.upload_images_for_training()
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
 
         # But set CoralNet's requirement 1 higher than that image count.
         min_images = self.source.image_set.count() + 1
@@ -499,7 +498,7 @@ class AbortCasesTest(BaseTaskTest, EmailAssertionsMixin, ErrorReportTestMixin):
         self.upload_images_for_training()
         # Extract features
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
 
         # Create a classifier in another source.
         other_source = self.create_source(self.user)
@@ -528,7 +527,7 @@ class AbortCasesTest(BaseTaskTest, EmailAssertionsMixin, ErrorReportTestMixin):
 
         # Extract features normally.
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
 
         # Say one training image's features are legacy format.
         train_image = train_images[0]
@@ -561,7 +560,7 @@ class AbortCasesTest(BaseTaskTest, EmailAssertionsMixin, ErrorReportTestMixin):
 
         # Extract features normally.
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
 
         # Say at least one validation image's features are legacy format.
         for image in [val_images[0], val_images[1]]:
@@ -595,7 +594,7 @@ class AbortCasesTest(BaseTaskTest, EmailAssertionsMixin, ErrorReportTestMixin):
 
         # Extract features normally.
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
 
         # Say at least one image's features are a different extractor format.
         for image in [train_images[0], val_images[0]]:
@@ -622,7 +621,7 @@ class AbortCasesTest(BaseTaskTest, EmailAssertionsMixin, ErrorReportTestMixin):
                 self.user, img, annotations)
         # Extract features.
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
 
         # Try to train classifier.
         run_scheduled_jobs_until_empty()
@@ -680,7 +679,7 @@ class AbortCasesTest(BaseTaskTest, EmailAssertionsMixin, ErrorReportTestMixin):
         # Prepare training images + features.
         self.upload_images_for_training()
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
 
         # Submit training, with a spacer function mocked to
         # throw an error.
@@ -690,7 +689,7 @@ class AbortCasesTest(BaseTaskTest, EmailAssertionsMixin, ErrorReportTestMixin):
             run_scheduled_jobs_until_empty()
 
         # Collect training.
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
 
         self.assert_job_failure_message(
             'train_classifier',
@@ -728,7 +727,7 @@ class AbortCasesTest(BaseTaskTest, EmailAssertionsMixin, ErrorReportTestMixin):
 
         # Prepare features.
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
         for image in all_images:
             image.features.refresh_from_db()
             self.assertTrue(
@@ -769,7 +768,7 @@ class AbortCasesTest(BaseTaskTest, EmailAssertionsMixin, ErrorReportTestMixin):
             msg="Sanity check: points should have actually changed")
 
         # Collect training.
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
 
         self.assert_job_failure_message(
             'train_classifier',
@@ -793,7 +792,7 @@ class AbortCasesTest(BaseTaskTest, EmailAssertionsMixin, ErrorReportTestMixin):
         self.upload_images_for_training()
         # Extract features.
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
         # Train classifier.
         run_scheduled_jobs_until_empty()
 
@@ -805,7 +804,7 @@ class AbortCasesTest(BaseTaskTest, EmailAssertionsMixin, ErrorReportTestMixin):
         # Collect. The deleted Job shouldn't cause particular issues.
         # The corresponding BatchJob is considered successful, and besides
         # that there's no Job to mark the status of.
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
         self.assert_job_result_message(
             'collect_spacer_jobs',
             "Jobs checked/collected: 1 SUCCEEDED",
@@ -819,7 +818,7 @@ class AbortCasesTest(BaseTaskTest, EmailAssertionsMixin, ErrorReportTestMixin):
         self.upload_images_for_training()
         # Extract features.
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
         # Train classifier.
         run_scheduled_jobs_until_empty()
 
@@ -829,7 +828,7 @@ class AbortCasesTest(BaseTaskTest, EmailAssertionsMixin, ErrorReportTestMixin):
         classifier.delete()
 
         # Collect training.
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
 
         self.assert_job_failure_message(
             'train_classifier',
@@ -849,19 +848,19 @@ class AbortCasesTest(BaseTaskTest, EmailAssertionsMixin, ErrorReportTestMixin):
         # Train one classifier.
         self.upload_images_for_training()
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
         run_scheduled_jobs_until_empty()
         with mock_training_results(
             acc_custom=0.5,
             pc_accs_custom=[],
         ):
-            do_collect_spacer_jobs()
+            self.do_collect_spacer_jobs()
 
         # Upload enough additional images for the next training to happen.
         self.upload_images_for_training(
             train_image_count=2, val_image_count=0)
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
         run_scheduled_jobs_until_empty()
 
         # Collect classifier. Use mock to ensure a low enough accuracy
@@ -870,7 +869,7 @@ class AbortCasesTest(BaseTaskTest, EmailAssertionsMixin, ErrorReportTestMixin):
             acc_custom=0.74,
             pc_accs_custom=[0.5],
         ):
-            do_collect_spacer_jobs()
+            self.do_collect_spacer_jobs()
 
         classifier = self.source.classifier_set.latest('pk')
         self.assertEqual(classifier.status, Classifier.REJECTED_ACCURACY)
@@ -905,7 +904,7 @@ class TrainRefValSetsTest(BaseTaskTest):
     def do_test(self, expected_set_sizes):
         # Extract features.
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
 
         # Train classifier.
         with mock.patch(
@@ -991,7 +990,7 @@ class LabelFilteringTest(BaseTaskTest):
 
         # Extract features normally.
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
 
         # Try to train.
         job = do_job(

--- a/project/vision_backend/tests/tasks/utils.py
+++ b/project/vision_backend/tests/tasks/utils.py
@@ -90,11 +90,13 @@ class BaseTaskTest(ClientTest, UploadAnnotationsCsvTestMixin, JobUtilsMixin):
     @classmethod
     def upload_image_with_annotations(
         cls, filename,
-        source=None, annotation_scheme='cycle', label_codes=None,
+        source=None, user=None,
+        annotation_scheme='cycle', label_codes=None,
     ):
         source = source or cls.source
+        user = user or cls.user
         img = cls.upload_image(
-            cls.user, source, image_options=dict(filename=filename))
+            user, source, image_options=dict(filename=filename))
         label_codes = label_codes or ['A', 'B']
 
         match annotation_scheme:
@@ -114,15 +116,17 @@ class BaseTaskTest(ClientTest, UploadAnnotationsCsvTestMixin, JobUtilsMixin):
             case _:
                 assert False, "label_choices should be a valid option"
 
-        cls.add_annotations(cls.user, img, annotations)
+        cls.add_annotations(user, img, annotations)
         return img
 
     @classmethod
     def upload_images_for_training(
-        cls, source=None, train_image_count=None, val_image_count=1,
+        cls, source=None, user=None,
+        train_image_count=None, val_image_count=1,
         annotation_scheme='cycle', label_codes=None,
     ):
         source = source or cls.source
+        user = user or cls.user
 
         if train_image_count is None:
             # Provide enough data for initial training
@@ -136,6 +140,7 @@ class BaseTaskTest(ClientTest, UploadAnnotationsCsvTestMixin, JobUtilsMixin):
                 cls.upload_image_with_annotations(
                     'train{}.png'.format(cls.image_count),
                     source=source,
+                    user=user,
                     annotation_scheme=annotation_scheme,
                     label_codes=label_codes,
                 )
@@ -145,6 +150,7 @@ class BaseTaskTest(ClientTest, UploadAnnotationsCsvTestMixin, JobUtilsMixin):
                 cls.upload_image_with_annotations(
                     'val{}.png'.format(cls.image_count),
                     source=source,
+                    user=user,
                     annotation_scheme=annotation_scheme,
                     label_codes=label_codes,
                 )
@@ -154,11 +160,13 @@ class BaseTaskTest(ClientTest, UploadAnnotationsCsvTestMixin, JobUtilsMixin):
 
     @classmethod
     def upload_data_and_train_classifier(
-        cls, source=None, new_train_images_count=None,
+        cls, source=None, user=None, new_train_images_count=None,
     ):
         source = source or cls.source
+        user = user or cls.user
         train_images, val_images = cls.upload_images_for_training(
             source=source,
+            user=user,
             train_image_count=new_train_images_count,
             val_image_count=1,
         )

--- a/project/vision_backend/tests/tasks/utils.py
+++ b/project/vision_backend/tests/tasks/utils.py
@@ -8,11 +8,8 @@ from jobs.models import Job
 from jobs.tests.utils import do_job, JobUtilsMixin
 from jobs.utils import abort_job
 from lib.tests.utils import ClientTest
+from lib.tests.utils_data import DataTestMixin
 from ...models import Classifier
-
-
-def do_collect_spacer_jobs():
-    return do_job('collect_spacer_jobs')
 
 
 def source_check_is_scheduled(source_id):
@@ -40,30 +37,20 @@ def ensure_source_check_not_scheduled(source_id):
         abort_job(job.pk)
 
 
-@override_settings(
-    SPACER_QUEUE_CHOICE='vision_backend.queues.LocalQueue',
-    # Setting this False allows us to:
-    # - Use run_scheduled_jobs_until_empty() without infinite looping.
-    # - Run jobs like collect_spacer_jobs only when we explicitly want to.
-    ENABLE_PERIODIC_JOBS=False,
-)
-class BaseTaskTest(ClientTest, UploadAnnotationsCsvTestMixin, JobUtilsMixin):
-    """Base test class for testing the backend's 'main' tasks."""
+class TaskTestMixin(
+    DataTestMixin, JobUtilsMixin, UploadAnnotationsCsvTestMixin
+):
+    """Mixin for testing the backend's 'main' tasks."""
+
+    source: 'Source'
+    user: 'User'
 
     @classmethod
-    def setUpTestData(cls):
-        super().setUpTestData()
-
-        cls.user = cls.create_user()
-        cls.source = cls.create_source(
-            cls.user,
-            default_point_generation_method=dict(type='simple', points=5))
-        cls.labels = cls.create_labels(cls.user, ['A', 'B', 'C'], "Group1")
-        cls.create_labelset(cls.user, cls.source, cls.labels)
-
-    def setUp(self):
-        super().setUp()
-        self.source.refresh_from_db()
+    def do_collect_spacer_jobs(cls):
+        # This job schedules source checks on commit, and so this
+        # context manager ensures those checks run during the tests.
+        with cls.captureOnCommitCallbacks(execute=True):
+            return do_job('collect_spacer_jobs')
 
     def assertExistsInStorage(self, filepath):
         self.assertTrue(default_storage.exists(filepath))
@@ -176,11 +163,11 @@ class BaseTaskTest(ClientTest, UploadAnnotationsCsvTestMixin, JobUtilsMixin):
         # other job runs in the meantime.
         for image in [*train_images, *val_images]:
             do_job('extract_features', image.pk, source_id=source.pk)
-        do_collect_spacer_jobs()
+        cls.do_collect_spacer_jobs()
         # Train classifier
         job = do_job(
             'train_classifier', source.pk, source_id=source.pk)
-        do_collect_spacer_jobs()
+        cls.do_collect_spacer_jobs()
 
         return Classifier.objects.get(train_job_id=job.pk)
 
@@ -192,7 +179,7 @@ class BaseTaskTest(ClientTest, UploadAnnotationsCsvTestMixin, JobUtilsMixin):
         image = cls.upload_image(cls.user, source)
         # Extract features
         do_job('extract_features', image.pk, source_id=source.pk)
-        do_collect_spacer_jobs()
+        cls.do_collect_spacer_jobs()
 
         image.refresh_from_db()
         return image
@@ -242,3 +229,29 @@ class BaseTaskTest(ClientTest, UploadAnnotationsCsvTestMixin, JobUtilsMixin):
         return img
 
     rowcols_with_dupes_included = [(40, 60), (50, 50), (50, 50)]
+
+
+@override_settings(
+    SPACER_QUEUE_CHOICE='vision_backend.queues.LocalQueue',
+    # Setting this False allows us to:
+    # - Use run_scheduled_jobs_until_empty() without infinite looping.
+    # - Run jobs like collect_spacer_jobs only when we explicitly want to.
+    ENABLE_PERIODIC_JOBS=False,
+)
+class BaseTaskTest(ClientTest, TaskTestMixin):
+    """This is more 'batteries included' than TaskTestMixin."""
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.user = cls.create_user()
+        cls.source = cls.create_source(
+            cls.user,
+            default_point_generation_method=dict(type='simple', points=5))
+        cls.labels = cls.create_labels(cls.user, ['A', 'B', 'C'], "Group1")
+        cls.create_labelset(cls.user, cls.source, cls.labels)
+
+    def setUp(self):
+        super().setUp()
+        self.source.refresh_from_db()

--- a/project/vision_backend/tests/test_commands.py
+++ b/project/vision_backend/tests/test_commands.py
@@ -12,7 +12,7 @@ from jobs.utils import schedule_job
 from lib.storage_backends import get_storage_manager
 from lib.tests.utils import ManagementCommandTest
 from ..models import Features
-from .tasks.utils import do_collect_spacer_jobs
+from .tasks.utils import TaskTestMixin
 
 
 class MockOpenFactory:
@@ -122,7 +122,7 @@ class CheckAllSourcesTest(ManagementCommandTest):
 
 
 @override_settings(ENABLE_PERIODIC_JOBS=False)
-class ResetFeaturesTest(ManagementCommandTest):
+class ResetFeaturesTest(ManagementCommandTest, TaskTestMixin):
 
     @classmethod
     def setUpTestData(cls):
@@ -142,7 +142,7 @@ class ResetFeaturesTest(ManagementCommandTest):
 
         # Extract features
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        cls.do_collect_spacer_jobs()
         # Let remaining check_source jobs run (they should have nothing to do)
         run_scheduled_jobs_until_empty()
 
@@ -243,7 +243,7 @@ class ResetFeaturesTest(ManagementCommandTest):
 
 
 @override_settings(ENABLE_PERIODIC_JOBS=False)
-class InspectExtractedFeaturesTest(ManagementCommandTest):
+class InspectExtractedFeaturesTest(ManagementCommandTest, TaskTestMixin):
 
     @classmethod
     def setUpTestData(cls):
@@ -307,7 +307,7 @@ class InspectExtractedFeaturesTest(ManagementCommandTest):
     def test_features_ok(self):
         # Extract features normally.
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
 
         stdout_text, features_log_content, errors_json = self.call_command(
             'image_ids', '--ids', self.image_1a.pk,
@@ -340,7 +340,7 @@ class InspectExtractedFeaturesTest(ManagementCommandTest):
     def test_bad_feature_dim(self):
         # Extract features normally.
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
 
         # Modify features to have a mismatching feature_dim attribute.
         feature_loc = self.image_1a.features.data_loc
@@ -368,7 +368,7 @@ class InspectExtractedFeaturesTest(ManagementCommandTest):
     def test_rowcol_mismatch(self):
         # Extract features normally.
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
 
         # Change a point without clearing features.
         point = self.image_1a.point_set.get(point_number=1)
@@ -398,7 +398,7 @@ class InspectExtractedFeaturesTest(ManagementCommandTest):
     def test_legacy_ok(self):
         # Extract features normally.
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
 
         # Change features to the legacy format.
         feature_loc = self.image_1a.features.data_loc
@@ -418,7 +418,7 @@ class InspectExtractedFeaturesTest(ManagementCommandTest):
     def test_legacy_count_mismatch(self):
         # Extract features normally.
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
 
         # Change features to the legacy format and change the length.
         feature_loc = self.image_1a.features.data_loc
@@ -547,7 +547,7 @@ class InspectExtractedFeaturesTest(ManagementCommandTest):
     def test_do_correct(self):
         # Extract features
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
         # Let remaining check_source jobs run (they should have nothing to do)
         run_scheduled_jobs_until_empty()
 

--- a/project/vision_backend/tests/test_queues.py
+++ b/project/vision_backend/tests/test_queues.py
@@ -94,7 +94,10 @@ class MockBotoClient:
         for batch_token in jobs:
             if batch_token not in self.jobs:
                 continue
-            jobs_to_return.append(dict(status=self.jobs[batch_token]))
+            jobs_to_return.append(dict(
+                jobId=batch_token,
+                status=self.jobs[batch_token],
+            ))
 
         return dict(jobs=jobs_to_return)
 

--- a/project/vision_backend/tests/test_queues.py
+++ b/project/vision_backend/tests/test_queues.py
@@ -15,7 +15,7 @@ from jobs.tests.utils import do_job, JobUtilsMixin
 from vision_backend_api.tests.utils import DeployBaseTest
 from ..models import BatchJob, Classifier
 from ..queues import get_queue_class
-from .tasks.utils import BaseTaskTest, do_collect_spacer_jobs
+from .tasks.utils import BaseTaskTest
 
 
 def local_queue_decorator(func):
@@ -125,7 +125,7 @@ class QueueBasicTest(BaseTaskTest):
     to 'parameterize' these tests.
     """
     def do_test_no_jobs(self):
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
         self.assert_job_result_message(
             'collect_spacer_jobs', "Jobs checked/collected: 0")
 
@@ -134,7 +134,7 @@ class QueueBasicTest(BaseTaskTest):
         # Submit feature extraction
         run_scheduled_jobs_until_empty()
         # Collect
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
         self.assert_job_result_message(
             'collect_spacer_jobs', "Jobs checked/collected: 1 SUCCEEDED")
         # Check for successful result handling
@@ -144,11 +144,11 @@ class QueueBasicTest(BaseTaskTest):
         self.upload_images_for_training()
         # Feature extraction
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
         # Submit training
         run_scheduled_jobs_until_empty()
         # Collect
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
         self.assert_job_result_message(
             'collect_spacer_jobs', "Jobs checked/collected: 1 SUCCEEDED")
         # Check for successful result handling
@@ -164,11 +164,11 @@ class QueueBasicTest(BaseTaskTest):
         # Submit feature extraction
         run_scheduled_jobs_until_empty()
         # Collect
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
         self.assert_job_result_message(
             'collect_spacer_jobs', "Jobs checked/collected: 1 SUCCEEDED")
         # Collect again; job should already be consumed
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
         self.assert_job_result_message(
             'collect_spacer_jobs', "Jobs checked/collected: 0")
 
@@ -216,7 +216,7 @@ class BatchQueueBasicTest(QueueBasicTest):
             # Submit feature extraction
             run_scheduled_jobs_until_empty()
             # Collect
-            do_collect_spacer_jobs()
+            self.do_collect_spacer_jobs()
             self.assert_job_result_message(
                 'collect_spacer_jobs', "Jobs checked/collected: 1 FAILED")
 
@@ -231,13 +231,13 @@ class BatchQueueBasicTest(QueueBasicTest):
         with mock_boto_client():
             # Feature extraction
             run_scheduled_jobs_until_empty()
-            do_collect_spacer_jobs()
+            self.do_collect_spacer_jobs()
 
         with mock_boto_client('failed'):
             # Submit training
             run_scheduled_jobs_until_empty()
             # Collect
-            do_collect_spacer_jobs()
+            self.do_collect_spacer_jobs()
             self.assert_job_result_message(
                 'collect_spacer_jobs', "Jobs checked/collected: 1 FAILED")
 
@@ -259,7 +259,7 @@ class QueueClassificationTest(DeployBaseTest, JobUtilsMixin):
         # Submit classification
         self.run_scheduled_jobs_including_deploy()
         # Collect
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
         self.assert_job_result_message(
             'collect_spacer_jobs', "Jobs checked/collected: 1 SUCCEEDED")
         # Check for successful result handling
@@ -300,7 +300,7 @@ class QueueClassificationTest(DeployBaseTest, JobUtilsMixin):
         self.run_scheduled_jobs_including_deploy()
 
         # Collect
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
         self.assert_job_result_message(
             'collect_spacer_jobs', "Jobs checked/collected: 8 SUCCEEDED")
 
@@ -347,7 +347,7 @@ class BatchQueueClassificationTest(QueueClassificationTest):
             # Submit classification
             self.run_scheduled_jobs_including_deploy()
             # Collect
-            do_collect_spacer_jobs()
+            self.do_collect_spacer_jobs()
             self.assert_job_result_message(
                 'collect_spacer_jobs', "Jobs checked/collected: 1 FAILED")
 
@@ -363,7 +363,7 @@ class BatchQueueSpecificsTest(BaseTaskTest):
         # Submit feature extraction
         run_scheduled_jobs_until_empty()
         # Collect
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
         self.assert_job_result_message(
             'collect_spacer_jobs',
             f"Jobs checked/collected: {expected_counts_str}")
@@ -396,7 +396,7 @@ class BatchQueueSpecificsTest(BaseTaskTest):
             run_scheduled_jobs_until_empty()
 
             # Try to collect
-            do_collect_spacer_jobs()
+            self.do_collect_spacer_jobs()
             self.assert_job_result_message(
                 'collect_spacer_jobs',
                 "Jobs checked/collected: 1 NOT SUBMITTED")
@@ -409,7 +409,7 @@ class BatchQueueSpecificsTest(BaseTaskTest):
             batch_job.save()
 
             # Then try to collect again.
-            do_collect_spacer_jobs()
+            self.do_collect_spacer_jobs()
             self.assert_job_result_message(
                 'collect_spacer_jobs',
                 "Jobs checked/collected: 1 DROPPED")
@@ -517,7 +517,7 @@ class JobSpecsTest(BaseTaskTest):
 
             do_job('extract_features', image.pk, source_id=self.source.pk)
 
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
 
         with (
             mock.patch.object(get_queue_class(), 'submit_job')

--- a/project/vision_backend/tests/test_task_helpers.py
+++ b/project/vision_backend/tests/test_task_helpers.py
@@ -1,11 +1,17 @@
-from spacer.messages import ClassifyImageMsg, JobMsg, JobReturnMsg, \
-    ClassifyReturnMsg, DataLocation
+from spacer.messages import (
+    ClassifyImageMsg,
+    ClassifyReturnMsg,
+    DataLocation,
+    JobMsg,
+    JobReturnMsg,
+)
 
 from annotations.models import Label
 from api_core.models import ApiJob, ApiJobUnit
 from jobs.models import Job
 from jobs.tests.utils import fabricate_job
 from lib.tests.utils import ClientTest
+from ..common import Extractors
 from ..task_helpers import SpacerClassifyResultHandler
 from ..utils import get_extractor
 
@@ -57,7 +63,7 @@ class TestDeployCollector(ClientTest):
         cls.task = ClassifyImageMsg(
             job_token=str(internal_job.pk),
             image_loc=DataLocation(storage_type='url', key=''),
-            extractor=get_extractor('dummy'),
+            extractor=get_extractor(Extractors.DUMMY.value),
             rowcols=[(100, 100), (200, 200)],
             classifier_loc=DataLocation(storage_type='memory', key=''),
         )
@@ -81,7 +87,7 @@ class TestDeployCollector(ClientTest):
             error_message=None,
         )
 
-        SpacerClassifyResultHandler.handle(job_res)
+        SpacerClassifyResultHandler().handle_job_results([job_res])
 
         api_job_unit = ApiJobUnit.objects.get(pk=self.api_job_unit_pk)
         self.assertEqual(api_job_unit.status, Job.Status.SUCCESS)
@@ -118,7 +124,7 @@ class TestDeployCollector(ClientTest):
             error_message='SomeError: File not found'
         )
 
-        SpacerClassifyResultHandler.handle(job_res)
+        SpacerClassifyResultHandler().handle_job_results([job_res])
 
         api_job_unit = ApiJobUnit.objects.get(pk=self.api_job_unit_pk)
         self.assertEqual(api_job_unit.status, Job.Status.FAILURE)

--- a/project/vision_backend/tests/test_views.py
+++ b/project/vision_backend/tests/test_views.py
@@ -11,7 +11,7 @@ from labels.models import Label
 from lib.tests.utils import (
     BasePermissionTest, ClientTest, HtmlAssertionsMixin, scrambled_run)
 from ..models import SourceCheckRequestEvent
-from .tasks.utils import do_collect_spacer_jobs, source_check_is_scheduled
+from .tasks.utils import source_check_is_scheduled, TaskTestMixin
 
 
 class PermissionTest(BasePermissionTest):
@@ -496,7 +496,7 @@ class RequestSourceCheckTest(ClientTest, HtmlAssertionsMixin, JobUtilsMixin):
         self.assertTrue(source_check_is_scheduled(self.source.pk))
 
 
-class BackendOverviewTest(ClientTest, HtmlAssertionsMixin):
+class BackendOverviewTest(ClientTest, HtmlAssertionsMixin, TaskTestMixin):
 
     @classmethod
     def setUpTestData(cls):
@@ -524,7 +524,7 @@ class BackendOverviewTest(ClientTest, HtmlAssertionsMixin):
         self.add_annotations(self.user, image1a)
         self.add_annotations(self.user, image1b)
         do_job('extract_features', image1c.pk, source_id=source1.pk)
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
 
         classifier2 = self.create_robot(source2)
         image2a = self.upload_image(self.user, source2)
@@ -536,7 +536,7 @@ class BackendOverviewTest(ClientTest, HtmlAssertionsMixin):
         self.add_robot_annotations(classifier2, image2b)
         self.add_robot_annotations(classifier2, image2c)
         do_job('extract_features', image2d.pk, source_id=source2.pk)
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
 
         self.client.force_login(self.superuser)
         response = self.client.get(self.url)

--- a/project/vision_backend_api/tests/test_deploy_result.py
+++ b/project/vision_backend_api/tests/test_deploy_result.py
@@ -10,7 +10,6 @@ from rest_framework import status
 from api_core.models import ApiJob, ApiJobUnit
 from api_core.tests.utils import BaseAPIPermissionTest
 from jobs.models import Job
-from vision_backend.tests.tasks.utils import do_collect_spacer_jobs
 from .utils import DeployBaseTest
 
 
@@ -222,7 +221,7 @@ class DeployResultEndpointTest(DeployBaseTest):
             'spacer.messages.ClassifyReturnMsg.__init__', mock_classify_return_msg
         ):
             self.run_scheduled_jobs_including_deploy()
-            do_collect_spacer_jobs()
+            self.do_collect_spacer_jobs()
 
         response = self.get_job_result(job)
 
@@ -334,7 +333,7 @@ class DeployResultEndpointTest(DeployBaseTest):
         ):
             # Complete both units.
             self.run_scheduled_jobs_including_deploy()
-            do_collect_spacer_jobs()
+            self.do_collect_spacer_jobs()
 
         # But go back and mark one as failed.
         unit_1, unit_2 = ApiJobUnit.objects.filter(
@@ -430,7 +429,7 @@ class QueriesTest(DeployBaseTest):
             self.deploy_url, data, **self.request_kwargs)
         # Complete job
         self.run_scheduled_jobs_including_deploy()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
 
         job = ApiJob.objects.latest('pk')
         url = reverse('api:deploy_result', args=[job.pk])

--- a/project/vision_backend_api/tests/test_deploy_status.py
+++ b/project/vision_backend_api/tests/test_deploy_status.py
@@ -9,7 +9,6 @@ from rest_framework import status
 from api_core.models import ApiJob, ApiJobUnit
 from api_core.tests.utils import BaseAPIPermissionTest
 from jobs.models import Job
-from vision_backend.tests.tasks.utils import do_collect_spacer_jobs
 from .utils import DeployBaseTest
 
 
@@ -248,7 +247,7 @@ class DeployStatusEndpointTest(DeployBaseTest):
     def test_success(self):
         job = self.schedule_deploy()
         self.run_scheduled_jobs_including_deploy()
-        do_collect_spacer_jobs()
+        self.do_collect_spacer_jobs()
 
         response = self.get_job_status(job)
 

--- a/project/vision_backend_api/tests/utils.py
+++ b/project/vision_backend_api/tests/utils.py
@@ -15,7 +15,7 @@ from jobs.utils import start_job
 from lib.tests.utils import ClientTest
 from lib.tests.utils_data import create_sample_image
 from sources.models import Source
-from vision_backend.tests.tasks.utils import do_collect_spacer_jobs
+from vision_backend.tests.tasks.utils import TaskTestMixin
 
 
 def mock_url_storage_load(*args) -> BytesIO:
@@ -32,7 +32,7 @@ def mock_url_storage_load(*args) -> BytesIO:
     return stream
 
 
-class DeployTestMixin(APITestMixin):
+class DeployTestMixin(APITestMixin, TaskTestMixin):
 
     @staticmethod
     def run_scheduled_jobs_including_deploy():
@@ -138,10 +138,10 @@ class DeployBaseTest(ClientTest, DeployTestMixin, metaclass=ABCMeta):
 
         # Extract features.
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        cls.do_collect_spacer_jobs()
         # Train a classifier.
         run_scheduled_jobs_until_empty()
-        do_collect_spacer_jobs()
+        cls.do_collect_spacer_jobs()
         cls.classifier = cls.source.last_accepted_classifier
 
         cls.deploy_url = reverse('api:deploy', args=[cls.classifier.pk])

--- a/project/vision_backend_api/tests/utils.py
+++ b/project/vision_backend_api/tests/utils.py
@@ -18,8 +18,51 @@ from sources.models import Source
 from vision_backend.tests.tasks.utils import do_collect_spacer_jobs
 
 
+def mock_url_storage_load(*args) -> BytesIO:
+    """
+    Returns a Pillow image as a stream. This can be used to mock
+    spacer.storage.URLStorage.load()
+    to bypass image-downloading from URL.
+    """
+    im = create_sample_image()
+    # Save the PIL image to an IO stream
+    stream = BytesIO()
+    im.save(stream, 'PNG')
+    # Return the (not yet closed) IO stream
+    return stream
+
+
+class DeployTestMixin(APITestMixin):
+
+    @staticmethod
+    def run_scheduled_jobs_including_deploy():
+        """
+        When running scheduled jobs which include deploy jobs, call this
+        method instead of run_scheduled_jobs_until_empty(), so that the
+        test doesn't have to download from any URLs.
+
+        Note that mock.patch() doesn't seem to reliably carry over with
+        test-subclassing, so this seems to be the better way to 'DRY' a
+        mock.patch().
+        """
+        with mock.patch(
+            'spacer.storage.URLStorage.load', mock_url_storage_load
+        ):
+            # Ensure the test class has a ENABLE_PERIODIC_JOBS=False
+            # settings override, for a call of this function to work.
+            run_scheduled_jobs_until_empty()
+
+    @staticmethod
+    def run_deploy_api_job(api_job):
+        with mock.patch(
+            'spacer.storage.URLStorage.load', mock_url_storage_load
+        ):
+            for unit in api_job.apijobunit_set.all():
+                start_job(unit.internal_job)
+
+
 @override_settings(ENABLE_PERIODIC_JOBS=False)
-class DeployBaseTest(ClientTest, APITestMixin, metaclass=ABCMeta):
+class DeployBaseTest(ClientTest, DeployTestMixin, metaclass=ABCMeta):
 
     @classmethod
     def setUpTestData(cls):
@@ -121,41 +164,3 @@ class DeployBaseTest(ClientTest, APITestMixin, metaclass=ABCMeta):
                     dict(row=10, column=10),
                 ])),
     ]))
-
-    @staticmethod
-    def run_scheduled_jobs_including_deploy():
-        """
-        When running scheduled jobs which include deploy jobs, call this
-        method instead of run_scheduled_jobs_until_empty(), so that the
-        test doesn't have to download from any URLs.
-
-        Note that mock.patch() doesn't seem to reliably carry over with
-        test-subclassing, so this seems to be the better way to 'DRY' a
-        mock.patch().
-        """
-        with mock.patch(
-            'spacer.storage.URLStorage.load', mock_url_storage_load
-        ):
-            run_scheduled_jobs_until_empty()
-
-    @staticmethod
-    def run_deploy_api_job(api_job):
-        with mock.patch(
-            'spacer.storage.URLStorage.load', mock_url_storage_load
-        ):
-            for unit in api_job.apijobunit_set.all():
-                start_job(unit.internal_job)
-
-
-def mock_url_storage_load(*args) -> BytesIO:
-    """
-    Returns a Pillow image as a stream. This can be used to mock
-    spacer.storage.URLStorage.load()
-    to bypass image-downloading from URL.
-    """
-    im = create_sample_image()
-    # Save the PIL image to an IO stream
-    stream = BytesIO()
-    im.save(stream, 'PNG')
-    # Return the (not yet closed) IO stream
-    return stream


### PR DESCRIPTION
As a result of the API optimizations in PR #597, I noticed a stretch of maybe 10 collect_spacer_jobs runs in production where it was collecting an average of 300 or so jobs per run, and the runs (which are supposed to go every 2 minutes) were falling slightly behind steadily (meaning they were taking an average of 2+ minutes each) until the job demand decreased again. I don't think we've sustained that rate for very long anytime recently, so this situation hasn't caused a noticeable site slowdown. But given that we're trying to raise our API usage capacity, possibly by a lot, it seemed like an imminent bottleneck to address.

Two types of optimizations I thought to make here, needing moderate effort:

- Requesting AWS Batch job statuses is done in batches of 100 at a time (the max that boto allows for one request) instead of one at a time.

- Optimized database queries done in collect_spacer_jobs:

  - Collecting classify (API deploy) jobs now uses less than O(n) queries.
  - Collecting feature-extract jobs still has an O(n) factor, seemingly 3 queries per image, as I've pointed out in the corresponding queries-test class.
  - Collecting train jobs isn't optimized at all because I don't expect there to be many train jobs to collect at once.

Comments:

- Retrieval of job result messages from S3 is still done one image at a time, and I'm not sure how much that might be a bottleneck right now. If needed, one potential road to addressing that is to batch up multiple extract/classify jobs into a single spacer request. Part of spacer's design already has that capability in mind, but since CoralNet hasn't used that at all yet, it's not battle-tested yet.

- Another potential API bottleneck area to keep an eye out for is the task which submits the deploy jobs to AWS Batch. Haven't measured it yet, though.

- Kind of unsatisfying how this led to adding 200 or so lines of code to task_helpers.py and queues.py combined, but oh well. Maybe later there'll be ideas to make it more concise.