### PR TITLE
Backend overview: short-circuit if there are zero images

### DIFF
--- a/project/vision_backend/tests/test_views.py
+++ b/project/vision_backend/tests/test_views.py
@@ -3,6 +3,7 @@ import datetime
 from bs4 import BeautifulSoup
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.html import escape
 
 from export.tests.utils import BaseExportTest
 from jobs.models import Job
@@ -622,3 +623,18 @@ class BackendOverviewTest(ClientTest, HtmlAssertionsMixin, TaskTestMixin):
         sources_table_soup = response_soup.select(
             'table#sources-table')[0]
         self.assert_table_values(sources_table_soup, expected_rows)
+
+    def test_zero_images(self):
+        # We have sources, but no images.
+        self.create_source(self.user)
+        self.create_source(self.user)
+
+        self.client.force_login(self.superuser)
+        response = self.client.get(self.url)
+        self.assertTemplateUsed(response, 'lib/function_unavailable.html')
+        self.assertContains(
+            response,
+            escape(
+                "There are no images on the site yet, so this page"
+                " has no useful information to show."
+            ))

--- a/project/vision_backend/views.py
+++ b/project/vision_backend/views.py
@@ -31,6 +31,12 @@ def backend_overview(request):
     images_all = Image.objects.all()
     total = images_all.count()
 
+    if total == 0:
+        return render(request, 'lib/function_unavailable.html', {
+            'message': "There are no images on the site yet, so this page"
+                       " has no useful information to show.",
+        })
+
     confirmed = images_all.confirmed().count()
     unconfirmed = images_all.unconfirmed().count()
     images_unclassified = images_all.unclassified()


### PR DESCRIPTION
Follow-up on PR #598, with a different approach - short-circuiting out of the page instead of getting the stats to work with zero images.

Now in this case, visiting the URL should just show a single line: "There are no images on the site yet, so this page has no useful information to show."

