### PR TITLE
Two intermittent test error fix attempts

### DIFF
--- a/project/vision_backend/tests/tasks/test_extract_features.py
+++ b/project/vision_backend/tests/tasks/test_extract_features.py
@@ -157,7 +157,11 @@ class ExtractFeaturesTest(BaseTaskTest):
             self.rowcols_with_dupes_included, sorted(rowcols),
             "Feature rowcols should match the actual points including dupes")
 
-    @override_settings(SPACER={'MAX_IMAGE_PIXELS': 100})
+    @override_settings(
+        TRAINING_MIN_IMAGES=3,
+        NEW_CLASSIFIER_TRAIN_TH=1.1,
+        SPACER={'MAX_IMAGE_PIXELS': 100},
+    )
     def test_resolution_too_large(self):
         # Upload enough within-limit images for training.
         # (The too-large message only shows when the source has a classifier.)


### PR DESCRIPTION
`SourceMainBackendColumnTest.test_has_own_classifiers()`: Simplifies the code for the second training, in hopes of removing/exposing an intermittent error seen in PR #606. The intermittent error was at `self.assertEqual(classifier_2.status, Classifier.REJECTED_ACCURACY)`; status was accepted instead.

`ExtractFeaturesTest.test_resolution_too_large()`: Makes training-requirements settings explicit, in hopes of removing an intermittent error seen in this PR. The intermittent error was at `self.source_check_and_assert(...)`; the message was "Can't train first classifier: Need 5 annotated images for next training, and currently have 4".