### PR TITLE
ApiJob finish_date fix + spacer Job modify_date fix

### DIFF
--- a/project/jobs/utils.py
+++ b/project/jobs/utils.py
@@ -248,6 +248,7 @@ def abort_job(job_id: int):
 
 def finish_jobs(jobs_details: list[dict]):
     jobs = []
+    now = datetime.now(timezone.utc)
 
     for job_details in jobs_details:
         job = job_details['job']
@@ -255,8 +256,12 @@ def finish_jobs(jobs_details: list[dict]):
         job.status = (
             Job.Status.SUCCESS if job_details['success']
             else Job.Status.FAILURE)
+        # auto_now fields like modify_date don't get auto-updated by
+        # bulk_update(); so we set it explicitly here.
+        # https://docs.djangoproject.com/en/4.2/ref/models/fields/#django.db.models.DateField.auto_now
+        job.modify_date = now
         jobs.append(job)
-    Job.objects.bulk_update(jobs, ['result_message', 'status'])
+    Job.objects.bulk_update(jobs, ['result_message', 'status', 'modify_date'])
 
     # No periodic-job case. Periodic jobs should use finish_job() instead.
 


### PR DESCRIPTION
Fixing two regressions introduced by release 1.19.3:

- ApiJobs were getting their `finish_date` set if *any* of its ApiJobUnits finished, rather than if *all* of them finished. This should now be fixed. I don't know why the database query for this wasn't working as intended (I think it was always counting 0 pending and 0 in-progress job units), but it was on the complex side and stood to be simplified anyhow, so that's what I did.
- Jobs that were being finished in `collect_spacer_jobs()` weren't getting their `modify_date` set in the process. I'd overlooked the fact that `bulk_update()` does not set `auto_now` fields such as modify_date. So the fix was to set modify_date explicitly in the bulk_update().

For the record, the most visible result of the first regression was that if an ApiJob had some units finished in one round of `collect_spacer_jobs()`, and some still unfinished, then the whole ApiJob would still be considered finished by the user-status endpoint and deploy-result endpoints, but not the deploy-status endpoint.