### PR TITLE
CPC upload: check for the 1000-file limit in the UI

### DIFF
--- a/project/cpce/static/js/UploadAnnotationsCPCHelper.js
+++ b/project/cpce/static/js/UploadAnnotationsCPCHelper.js
@@ -18,6 +18,7 @@ var UploadAnnotationsCPCHelper = (function() {
 
     var uploadPreviewUrl = null;
     var uploadStartUrl = null;
+    var maxFiles = null;
 
 
     function updateStatus(newStatus) {
@@ -168,6 +169,13 @@ var UploadAnnotationsCPCHelper = (function() {
             updatePreviewTable();
             return;
         }
+        if (cpcFileField.files.length > maxFiles) {
+            cpcFileError =
+                `Can't upload more than ${maxFiles} files at a time.`;
+            updateStatus('preview_error');
+            updatePreviewTable();
+            return;
+        }
 
         updateStatus('processing');
         updatePreviewTable();
@@ -259,6 +267,7 @@ var UploadAnnotationsCPCHelper = (function() {
             // Get the parameters.
             uploadPreviewUrl = params['uploadPreviewUrl'];
             uploadStartUrl = params['uploadStartUrl'];
+            maxFiles = params['maxFiles'];
 
             // Upload status elements.
             $statusDisplay = $('#status_display');

--- a/project/cpce/templates/cpce/upload.html
+++ b/project/cpce/templates/cpce/upload.html
@@ -60,7 +60,8 @@
   <script type="text/javascript">
     UploadAnnotationsCPCHelper.initForm({
         uploadPreviewUrl: "{% url 'cpce:upload_preview_ajax' source.id %}",
-        uploadStartUrl: "{% url 'cpce:upload_confirm_ajax' source.id %}"
+        uploadStartUrl: "{% url 'cpce:upload_confirm_ajax' source.id %}",
+        maxFiles: {{ upload_max_files }},
     });
   </script>
 

--- a/project/cpce/views.py
+++ b/project/cpce/views.py
@@ -3,6 +3,7 @@ from io import StringIO
 import json
 from pathlib import PureWindowsPath
 
+from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import ValidationError
 from django.db.models import QuerySet
@@ -56,6 +57,7 @@ def upload_page(request, source_id):
     return render(request, 'cpce/upload.html', {
         'source': source,
         'cpc_import_form': cpc_import_form,
+        'upload_max_files': settings.DATA_UPLOAD_MAX_NUMBER_FILES,
     })
 
 


### PR DESCRIPTION
Back in PR #510, I noticed that the Django DATA_UPLOAD_MAX_NUMBER_FILES setting was effectively limiting the CPC upload file limit to 100. The way CPC upload currently works, all the files are sent in a single web request. The internal limit to how many files can be sent like this (on any page) exists because sending way too many files can make the server run out of memory (thus making it crash) or at least hog server resources uninterrupted for a while. With this in mind, I had settled on raising the limit from 100 to 1000, but I didn't address other aspects of user friendliness at the time.

With this PR, we'll now check for the 1000-file limit on the Javascript side, and display an appropriate message when you go over that, instead of letting it get sent to the Ajax preview URL and resulting in a cryptic "There was a server error" popup alert.

Note that there is still a solution that's preferable to this: reworking CPC upload to send files in small batches instead of all at once, thus allowing us to set the Django internal limit back to the default 100, and getting the best of both security and usability. However, that's a higher effort task, and it hasn't seemed to be a particularly pressing issue in practice yet.