### PR TITLE
Limit metadata dropdown length on Browse pages

### DIFF
--- a/project/config/settings.py
+++ b/project/config/settings.py
@@ -1356,6 +1356,11 @@ BROWSE_DEFAULT_THUMBNAILS_PER_PAGE = 20
 LABEL_EXAMPLE_PATCHES_PER_PAGE = 50
 LABEL_EXAMPLE_PATCHES_PER_PAGE_GUEST = 5
 
+# If a source has more than this many unique values for a given
+# aux. metadata model field, the corresponding search form field
+# becomes a free text field rather than a dropdown options field.
+BROWSE_METADATA_OPTION_LIMIT = 50
+
 # Image counts required for sources to: display on the map,
 # display as medium size, and display as large size.
 MAP_IMAGE_COUNT_TIERS = env.list(

--- a/project/static/css/master.css
+++ b/project/static/css/master.css
@@ -73,6 +73,8 @@ html {
      form fields look weird (at least on the Add/Remove Labels page) */
     --dialog-form-background-color: hsl(30, 18%, 95%);
 
+    --kbd-background-color: hsl(0, 0%, 87%);
+
     --top-message-outer-background-color: hsl(0, 0%, 7%);
     --top-message-normal-background-color: hsl(48, 86%, 92%);
     --top-message-maintenance-background-color: hsl(0, 100%, 90%);
@@ -127,6 +129,8 @@ html.dark-scheme {
 
     --dialog-background-color: hsl(210, 5%, 15%, 95%);
     --dialog-form-background-color: hsl(210, 5%, 15%);
+
+    --kbd-background-color: hsl(0, 0%, 25%);
 
     --top-message-outer-background-color: hsl(0, 0%, 30%);
     --top-message-normal-background-color: hsl(48, 50%, 30%);
@@ -396,7 +400,7 @@ kbd {
     font-size: 0.9em;
     line-height: 1.4em;
     padding: 0 2px;    /* 2px of horizontal padding */
-    background-color: #DDDDDD;
+    background-color: var(--kbd-background-color);
 
     border: 1px solid black;
     border-radius: 3px;

--- a/project/visualization/templates/visualization/help_browse.html
+++ b/project/visualization/templates/visualization/help_browse.html
@@ -14,11 +14,11 @@
 
 <ul>
   <li>The "Sort by" and "Direction" fields let you change the ordering of the search results.</li>
-  <li>The "Image name contains" field accepts punctuation, and accepts multiple search terms separated by spaces. So you can use search queries like <code>dsc_ .jpg</code> or <code>dupe-name</code>.</li>
+  <li>The "Image name contains" field accepts punctuation, and accepts multiple search terms separated by spaces. So you can use search queries like <kbd>.jpg dsc_</kbd> or <kbd>dupe-name</kbd>.</li>
   <li>
     If some of your images have values filled in for the auxiliary metadata fields, those metadata fields will appear on the search form. This will typically appear as a dropdown field, but it will be a text-input field if the source has a large number of unique values for that field.
     <ul>
-      <li>If it's a text-input field, entering <code>(none)</code> will search for blank values.</li>
+      <li>If it's a text-input field, entering <kbd>(none)</kbd> will search for blank values.</li>
     </ul>
   </li>
 </ul>

--- a/project/visualization/templates/visualization/help_browse.html
+++ b/project/visualization/templates/visualization/help_browse.html
@@ -10,13 +10,24 @@
   Below the grid, click the arrow buttons to go to the next or
   previous page.</p>
 
-<p>The search box at the top lets you choose a subset of images. Change the search fields, then click Search to apply the filters. The "Image name contains" field accepts punctuation, so you can use search queries like <i>dsc_ .jpg</i> or <i>dupe-name</i>. The "Sort by" and "Direction" fields let you change the ordering of the search results.</p>
+<p>The search box at the top lets you choose a subset of images. Change the search fields, then click Search to apply the filters. Some tips:</p>
+
+<ul>
+  <li>The "Sort by" and "Direction" fields let you change the ordering of the search results.</li>
+  <li>The "Image name contains" field accepts punctuation, and accepts multiple search terms separated by spaces. So you can use search queries like <code>dsc_ .jpg</code> or <code>dupe-name</code>.</li>
+  <li>
+    If some of your images have values filled in for the auxiliary metadata fields, those metadata fields will appear on the search form. This will typically appear as a dropdown field, but it will be a text-input field if the source has a large number of unique values for that field.
+    <ul>
+      <li>If it's a text-input field, entering <code>(none)</code> will search for blank values.</li>
+    </ul>
+  </li>
+</ul>
 
 <p>You can mouse-over an image thumbnail to see its filename and
   annotation status. The thumbnail's border color also indicates the
   image's annotation status.</p>
 
-<p>The Image Actions box below the page navigator lets you run an action on the current set of images. (You must be signed in to see the box.) Select an action with the left dropdown, then use the right dropdown to specify whether to apply the action to all images in the search, or just the images on this page. Depending on the action, additional explanations and options may appear as well. Click "Go" to run the action.</p>
+<p>The "Image Actions" box below the page navigator lets you run an action on the current set of images. (You must be signed in to see the box.) Select an action with the left dropdown, then use the right dropdown to specify whether to apply the action to all images in the search, or just the images on this page. Depending on the action, additional explanations and options may appear as well. Click "Go" to run the action.</p>
 
 
 <h3>Edit Metadata</h3>


### PR DESCRIPTION
For issue #139. When a metadata dropdown field on the Browse search form would have more than 50 options, use a text-input field instead of a dropdown field, so that the page loading / rendering / responsiveness isn't slowed down by all the options.

While I was at it, I changed the behavior when all images in the source have the same non-blank value for a metadata field. Instead of not showing the field at all in that case, it now shows a dropdown with that one value and (none) as the options. The previous behavior seemed more confusing than useful; even if the dropdown is technically redundant in that specific case, part of the point is that the source owner may not know which images have which values for that field, so they'd use the search form to confirm that.

The help button nearest to the Browse search form now explains, among other things, why a metadata field might appear as a dropdown or a text-input.