### PR TITLE
Browse Patches: only count up to 20000 results

### DIFF
--- a/project/blog/views.py
+++ b/project/blog/views.py
@@ -1,6 +1,6 @@
 from django.views.generic import ListView, DetailView
 
-from lib.utils import ViewPaginator
+from lib.utils import CustomPaginator
 from .models import BlogPost
 
 
@@ -25,9 +25,9 @@ class PostsList(ListView):
     def get_paginator(self, *args, **kwargs):
         """
         This allows us to use pagination_links.html, which has stuff specific
-        to our ViewPaginator class.
+        to our CustomPaginator class.
         """
-        return ViewPaginator(dict(), *args, **kwargs)
+        return CustomPaginator(dict(), *args, **kwargs)
 
 
 class PostDetail(DetailView):

--- a/project/config/settings.py
+++ b/project/config/settings.py
@@ -1361,6 +1361,10 @@ LABEL_EXAMPLE_PATCHES_PER_PAGE_GUEST = 5
 # becomes a free text field rather than a dropdown options field.
 BROWSE_METADATA_OPTION_LIMIT = 50
 
+# Max results to count in Browse Patches, because arbitrarily
+# high counts are a potential source of slow page loads.
+BROWSE_PATCHES_RESULT_LIMIT = 20000
+
 # Image counts required for sources to: display on the map,
 # display as medium size, and display as large size.
 MAP_IMAGE_COUNT_TIERS = env.list(

--- a/project/templates/pagination_links.html
+++ b/project/templates/pagination_links.html
@@ -4,6 +4,9 @@
     <div class="line"><span>
       Showing {{ page_results.start_index }}-{{ page_results.end_index }}
       of {{ page_results.paginator.count }}
+      {% if page_results.paginator.count_limit_reached %}
+        or more
+      {% endif %}
     </span></div>
   {% endif %}
 
@@ -25,4 +28,10 @@
     {% endif %}
 
   </div>
+
+  {% if page_results.paginator.count_limit_reached and not page_results.has_next %}
+    <div class="line">
+      Due to site performance limitations, this is the last page of search results we can show.
+    </div>
+  {% endif %}
 </div>

--- a/project/visualization/templates/visualization/help_browse.html
+++ b/project/visualization/templates/visualization/help_browse.html
@@ -56,5 +56,7 @@
   Mouse-over an image patch to see which image and which point the patch is
   from.</p>
 
+<p>If the search contains a very high number of annotations, it can be slow to count all the results, so we limit the result count if it's too high. The pagination text will show something like "Showing 1-20 out of 20000 or more" if this is the case.</p>
+
 
 </div>

--- a/project/visualization/views.py
+++ b/project/visualization/views.py
@@ -269,7 +269,9 @@ def browse_patches(request, source_id):
     page_results = paginate(
         annotation_results,
         settings.BROWSE_DEFAULT_THUMBNAILS_PER_PAGE,
-        request.GET)
+        request.GET,
+        count_limit=settings.BROWSE_PATCHES_RESULT_LIMIT,
+    )
 
     return render(request, 'visualization/browse_patches.html', {
         'source': source,


### PR DESCRIPTION
This means that, in a situation where the paginator would previously count 80000 results and give 4000 pages, we'd now only say "Showing m-n of 20000 or more" and give only up to 1000 pages.

This is implemented by having paginator.count call `self.object_list[:20000].count()` instead of `self.object_list.count()`. This apparently (by my testing thus far) allows the SQL count query to stop once it reaches 20000, thus giving us a speedup when there would be many more results in total.

Note that the count can still be very slow if many database rows have to be scanned to get to 20000 matching results. So having the right database indexes is still important, since that generally helps with reducing how many non-matching rows are sifted through.