### PR TITLE
Browse pages and example patches: reduce queries with `select_related()`

### DIFF
--- a/project/async_media/tasks.py
+++ b/project/async_media/tasks.py
@@ -30,9 +30,9 @@ def generate_patch(point_id: int):
     Generate an image patch centered around an annotation point.
     """
     try:
-        Point.objects.get(pk=point_id)
+        point = Point.objects.get(pk=point_id)
     except Point.DoesNotExist:
         raise JobError(f"Point {point_id} doesn't exist anymore.")
 
-    generate_patch_if_doesnt_exist(point_id)
-    return get_patch_url(point_id)
+    generate_patch_if_doesnt_exist(point)
+    return get_patch_url(point)

--- a/project/async_media/templatetags/async_media_tags.py
+++ b/project/async_media/templatetags/async_media_tags.py
@@ -56,7 +56,7 @@ def patch_async(point, media_batch_key, request):
     """
     Image patch for an annotation point.
     """
-    media_item = AsyncPatch(point_id=point.pk)
+    media_item = AsyncPatch(point=point)
     return media_async(media_item, media_batch_key, request)
 
 

--- a/project/async_media/tests/tests.py
+++ b/project/async_media/tests/tests.py
@@ -499,7 +499,7 @@ class PatchesTest(AsyncMediaTest):
             # This assumes there is only one annotated image in the test
             point = Point.objects.get(point_number=point_number)
             comparable_expected_results[media_key] = make_media_url_comparable(
-                get_patch_url(point.pk))
+                get_patch_url(point))
 
         self.assertDictEqual(
             comparable_actual_results,
@@ -509,11 +509,11 @@ class PatchesTest(AsyncMediaTest):
     def test_load_existing_patch(self):
         img = self.upload_image(self.user, self.source)
         self.add_annotations(self.user, img, {1: 'A'})
-        point_id = img.point_set.get(point_number=1).pk
+        point = img.point_set.get(point_number=1)
 
         # Generate patch before loading browse page
-        generate_patch_if_doesnt_exist(point_id)
-        patch_url = get_patch_url(point_id)
+        generate_patch_if_doesnt_exist(point)
+        patch_url = get_patch_url(point)
 
         patch_image = self.load_browse_and_get_media()[0]
 
@@ -609,9 +609,9 @@ class PatchesTest(AsyncMediaTest):
 
         # Point numbers 1 and 3: already generated before loading browse page
         generate_patch_if_doesnt_exist(
-            Point.objects.get(point_number=1).pk)
+            Point.objects.get(point_number=1))
         generate_patch_if_doesnt_exist(
-            Point.objects.get(point_number=3).pk)
+            Point.objects.get(point_number=3))
 
         batch_key, media_keys = self.load_browse_and_get_media_keys()[0]
 

--- a/project/labels/tests/test_label_main.py
+++ b/project/labels/tests/test_label_main.py
@@ -442,11 +442,11 @@ class LabelMainPatchesTest(BaseLabelMainTest):
         self.image.annotation_set \
             .filter(point__point_number__in=[2, 4]).delete()
 
-        remaining_annotation_point_ids = set(
-            self.image.annotation_set.values_list('point_id', flat=True))
+        remaining_annotations = set(
+            self.image.annotation_set.select_related('point'))
         expected_thumbnail_filenames = set([
-            Path(get_patch_path(point_id)).name
-            for point_id in remaining_annotation_point_ids])
+            Path(get_patch_path(annotation.point)).name
+            for annotation in remaining_annotations])
 
         response = self.get_example_patches()
         patches_soup = BeautifulSoup(response['patchesHtml'], 'html.parser')

--- a/project/labels/views.py
+++ b/project/labels/views.py
@@ -482,7 +482,7 @@ def label_example_patches_ajax(request, label_id):
         image = point.image
         source = image.source
 
-        generate_patch_if_doesnt_exist(point.pk)
+        generate_patch_if_doesnt_exist(point)
 
         if source.visible_to_user(request.user):
             dest_url = reverse('image_detail', args=[image.pk])
@@ -492,7 +492,7 @@ def label_example_patches_ajax(request, label_id):
         patches.append(dict(
             source=source,
             dest_url=dest_url,
-            thumbnail_url=get_patch_url(point.id),
+            thumbnail_url=get_patch_url(point),
         ))
 
     return JsonResponse({

--- a/project/labels/views.py
+++ b/project/labels/views.py
@@ -476,11 +476,13 @@ def label_example_patches_ajax(request, label_id):
         patch_annotations = page_annotations.object_list
         is_last_page = page >= paginator.num_pages
 
+    patch_annotations = patch_annotations.select_related(
+        'point', 'point__image', 'source')
     patches = []
     for index, annotation in enumerate(patch_annotations):
         point = annotation.point
         image = point.image
-        source = image.source
+        source = annotation.source
 
         generate_patch_if_doesnt_exist(point)
 

--- a/project/visualization/tests/test_browse_images.py
+++ b/project/visualization/tests/test_browse_images.py
@@ -1219,6 +1219,27 @@ class ImageStatusIndicatorTest(BaseBrowseImagesTest):
         self.assertSetEqual(expected_thumb_set, actual_thumb_set)
 
 
+@override_settings(
+    # More results per page, to really make clear how the query count
+    # depends on results per page.
+    BROWSE_DEFAULT_THUMBNAILS_PER_PAGE=80,
+)
+class QueriesTest(BaseBrowseImagesTest):
+
+    setup_image_count = 80
+
+    def test(self):
+        # Should be less than 1 query per result
+        with self.assert_queries_less_than(80):
+            response = self.get_browse(**self.default_search_params)
+
+        self.assert_browse_results(
+            response,
+            self.images,
+            msg_prefix="Shouldn't have any issues preventing correct results",
+        )
+
+
 class BrowseImagesSeleniumTest(BaseBrowseSeleniumTest):
 
     def test_search_should_preserve_most_params(self):

--- a/project/visualization/tests/test_edit_metadata.py
+++ b/project/visualization/tests/test_edit_metadata.py
@@ -727,3 +727,19 @@ class SubmitEditsTest(BaseBrowseMetadataTest):
         image_s2.metadata.refresh_from_db()
         self.assertEqual(image_s2.metadata.name, old_name)
         self.assertEqual(image_s2.metadata.photo_date, None)
+
+
+class QueriesTest(BaseBrowseMetadataTest):
+
+    setup_image_count = 80
+
+    def test(self):
+        # Should be less than 1 query per result
+        with self.assert_queries_less_than(80):
+            response = self.get_browse(**self.default_search_params)
+
+        self.assert_browse_results(
+            response,
+            self.images,
+            msg_prefix="Shouldn't have any issues preventing correct results",
+        )

--- a/project/visualization/tests/test_utils.py
+++ b/project/visualization/tests/test_utils.py
@@ -41,16 +41,16 @@ class LabelPatchGenerationTest(ClientTest):
         img = self.upload_image(self.user, self.source,
                                 image_options={'mode': image_mode})
 
-        point_id = Point.objects.filter(image=img)[0].id
+        point = Point.objects.filter(image=img)[0]
 
         # Assert that patches can be generated without problems
         try:
-            generate_patch_if_doesnt_exist(point_id)
+            generate_patch_if_doesnt_exist(point)
         except IOError as msg:
             self.fail("Error occurred during patch generation: {}".format(msg))
 
         # Then assert the patch was actually generated and that it's RGB
-        with default_storage.open(get_patch_path(point_id)) as fp:
+        with default_storage.open(get_patch_path(point)) as fp:
             patch = PILImage.open(fp)
             self.assertEqual(patch.size[0], settings.LABELPATCH_NROWS)
             self.assertEqual(patch.size[1], settings.LABELPATCH_NCOLS)
@@ -142,9 +142,9 @@ class PatchCropTest(ClientTest):
         # a version that always saves PNG, ignoring the 'format' param passed
         # to save().
         with mock.patch.object(PILImage.Image, 'save', always_save_png):
-            generate_patch_if_doesnt_exist(point.pk)
+            generate_patch_if_doesnt_exist(point)
 
-        with default_storage.open(get_patch_path(point.pk)) as fp:
+        with default_storage.open(get_patch_path(point)) as fp:
             patch = PILImage.open(fp)
 
             # The patch should have 1 red pixel in the center (to be exact, the

--- a/project/visualization/utils.py
+++ b/project/visualization/utils.py
@@ -140,34 +140,31 @@ def get_annotation_tool_users(source):
     return User.objects.filter(pk__in=tool_user_pks).order_by('username')
 
 
-def get_patch_path(point_id):
-    point = Point.objects.get(pk=point_id)
-
+def get_patch_path(point):
     return settings.POINT_PATCH_FILE_PATTERN.format(
         full_image_path=point.image.original_file.name,
         point_pk=point.pk,
     )
 
 
-def get_patch_url(point_id):
-    return default_storage.url(get_patch_path(point_id))
+def get_patch_url(point):
+    return default_storage.url(get_patch_path(point))
 
 
-def generate_patch_if_doesnt_exist(point_id):
+def generate_patch_if_doesnt_exist(point):
     """
     If this point doesn't have an image patch file yet, then
     generate one.
-    :param point_id: Primary key to point object to generate a patch for
+    :param point: Point object to generate a patch for
     :return: None
     """
 
     # Check if patch exists for the point
-    patch_relative_path = get_patch_path(point_id)
+    patch_relative_path = get_patch_path(point)
     if default_storage.exists(patch_relative_path):
         return
 
     # Locate the image.
-    point = Point.objects.get(pk=point_id)
     image = point.image
     original_image_relative_path = image.original_file.name
 

--- a/project/visualization/views.py
+++ b/project/visualization/views.py
@@ -190,6 +190,7 @@ def edit_metadata(request, source_id):
     #
     # But for now, we always just sort by image name.
     image_results = image_results.order_by('metadata__name', 'pk')
+    image_results = image_results.select_related('annoinfo')
     num_images = image_results.count()
 
     # Formset of MetadataForms.

--- a/project/visualization/views.py
+++ b/project/visualization/views.py
@@ -272,6 +272,8 @@ def browse_patches(request, source_id):
         request.GET,
         count_limit=settings.BROWSE_PATCHES_RESULT_LIMIT,
     )
+    page_results.object_list = page_results.object_list.select_related(
+        'point', 'point__image', 'point__image__metadata')
 
     return render(request, 'visualization/browse_patches.html', {
         'source': source,

--- a/project/visualization/views.py
+++ b/project/visualization/views.py
@@ -70,6 +70,8 @@ def browse_images(request, source_id):
         image_results,
         settings.BROWSE_DEFAULT_THUMBNAILS_PER_PAGE,
         request.GET)
+    page_results.object_list = page_results.object_list.select_related(
+        'annoinfo', 'metadata')
 
     if page_results.paginator.count > 0:
         page_image_ids = [


### PR DESCRIPTION
I've really been overlooking `QuerySet.select_related()`. Compared to `values()` or `values_list()`, it can be potentially more benefit for a lot less refactoring effort.

I don't think these particular views were really bottlenecked by query count, but still nice to clear this up to help focus on other factors.