### PR TITLE
CPC batch editor: check for the 1000-file limit in the UI

### DIFF
--- a/project/cpce/templates/cpce/cpc_batch_editor.html
+++ b/project/cpce/templates/cpce/cpc_batch_editor.html
@@ -113,7 +113,7 @@
 
   {# Script in the body will run on page load. #}
   <script type="text/javascript">
-    let cpcBatchEditor = new CPCBatchEditor();
+    let cpcBatchEditor = new CPCBatchEditor({{ max_cpc_files }});
   </script>
 
 {% endblock %}

--- a/project/cpce/views.py
+++ b/project/cpce/views.py
@@ -509,6 +509,8 @@ class ExportPrepView(View):
 def cpc_batch_editor(request):
     return render(request, 'cpce/cpc_batch_editor.html', {
         'process_form': CpcBatchEditSpecForm(),
+        # Minus 1 so the CSV file can also be submitted.
+        'max_cpc_files': settings.DATA_UPLOAD_MAX_NUMBER_FILES - 1,
     })
 
 


### PR DESCRIPTION
Similar to PR #624, but applying to CPC batch editor here instead of CPC annotations upload.

The batch editor has you uploading a batch of CPC files along with one CSV file. So, reaching the limit means 999 CPC files plus 1 CSV file for a total of 1000.