### PR TITLE
Factor out saving of imported annotations into its own function

### DIFF
--- a/project/annotations/tests/test_upload_general_cases.py
+++ b/project/annotations/tests/test_upload_general_cases.py
@@ -273,7 +273,7 @@ class GeneralCasesTest(
         def raise_error(self, *args, **kwargs):
             raise ValueError
 
-        with mock.patch('annotations.views.reset_features', raise_error):
+        with mock.patch('annotations.utils.reset_features', raise_error):
             with self.assertRaises(ValueError):
                 self.upload_annotations(self.user, self.source)
 

--- a/project/cpce/tests/test_upload_general_cases.py
+++ b/project/cpce/tests/test_upload_general_cases.py
@@ -334,7 +334,7 @@ class GeneralCasesTest(
         def raise_error(self, *args, **kwargs):
             raise ValueError
 
-        with mock.patch('annotations.views.reset_features', raise_error):
+        with mock.patch('annotations.utils.reset_features', raise_error):
             with self.assertRaises(ValueError):
                 self.upload_annotations(self.user, self.source)
 

--- a/project/cpce/views.py
+++ b/project/cpce/views.py
@@ -131,9 +131,7 @@ class CpcAnnotationsUploadConfirmView(AnnotationsUploadConfirmView):
         source.cpce_image_dir = cpc.get_image_dir(image_id)
         source.save()
 
-    def update_image_and_metadata_fields(self, image, new_points):
-        super().update_image_and_metadata_fields(image, new_points)
-
+    def extra_image_level_actions(self, image):
         # Save uploaded CPC contents for future CPC exports.
         # Note: Since cpc_files went through session serialization,
         # the integer dict keys became stringified.


### PR DESCRIPTION
This way the logic can be used by management commands, not just views.

(The applicable management command will be in our internal repo for the time being.)