### PR TITLE
Disable certain views when CoralNet's email system is under maintenance

### DIFF
--- a/project/accounts/urls.py
+++ b/project/accounts/urls.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-from django.contrib.auth import views as auth_views
 from django.urls import include, path, re_path
 from django.views.generic.base import TemplateView
 from . import views
@@ -16,7 +15,7 @@ urlpatterns = [
              authentication_form=AuthenticationForm),
          name='login'),
     path('password_reset/',
-         auth_views.PasswordResetView.as_view(
+         views.PasswordResetView.as_view(
              extra_email_context=dict(
                 account_questions_link=settings.ACCOUNT_QUESTIONS_LINK)),
          name='password_reset'),

--- a/project/accounts/views.py
+++ b/project/accounts/views.py
@@ -3,11 +3,15 @@ from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required, permission_required
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.contrib.auth.views import LoginView as DefaultLoginView
+from django.contrib.auth.views import (
+    LoginView as DefaultLoginView,
+    PasswordResetView as DefaultPasswordResetView,
+)
 from django.core import signing
 from django.core.mail import EmailMessage
 from django.shortcuts import redirect, render, get_object_or_404
 from django.template.loader import render_to_string
+from django.utils.decorators import method_decorator
 from django.views.decorators.debug import sensitive_post_parameters
 from django.views.generic.base import TemplateView
 from django.views.generic.edit import FormView
@@ -15,6 +19,7 @@ from django.views.generic.edit import FormView
 from django_registration.backends.activation.views \
     import RegistrationView as ThirdPartyRegistrationView
 
+from lib.decorators import mail_maintenance_off
 from lib.utils import paginate
 from .forms import (
     ActivationResendForm, EmailAllForm, EmailChangeForm,
@@ -56,6 +61,7 @@ class BaseRegistrationView(ThirdPartyRegistrationView):
         return context
 
 
+@mail_maintenance_off
 @sensitive_post_parameters()
 def register(request, *args, **kwargs):
     return RegistrationView.as_view()(request, *args, **kwargs)
@@ -133,6 +139,11 @@ class RegistrationView(BaseRegistrationView):
         already_exists_email.send()
 
 
+@method_decorator(
+    [
+        mail_maintenance_off
+    ],
+    name='dispatch')
 class ActivationResendView(BaseRegistrationView):
     """
     Activation-email sending functionality is defined in the registration view
@@ -170,6 +181,20 @@ class ActivationResendView(BaseRegistrationView):
         return FormView.get_form(self, form_class=form_class)
 
 
+@method_decorator(
+    [
+        mail_maintenance_off
+    ],
+    name='dispatch')
+class PasswordResetView(DefaultPasswordResetView):
+    pass
+
+
+@method_decorator(
+    [
+        mail_maintenance_off
+    ],
+    name='dispatch')
 class EmailChangeView(LoginRequiredMixin, FormView):
     form_class = EmailChangeForm
     success_url = 'email_change_done'


### PR DESCRIPTION
Such maintenance is determined by directly reading an env var, `CORALNET_MAIL_MAINTENANCE`. This allows us to set the value without restarting the web server (unlike when we use the `.env` file).