### PR TITLE
Informality disclaimer on privacy policy

### DIFF
--- a/project/accounts/templates/django_registration/activation_email_body.txt
+++ b/project/accounts/templates/django_registration/activation_email_body.txt
@@ -17,7 +17,7 @@ Here are some resources to help get you started with the site:
 
 3) If you have any issues with your CoralNet user account, you can post in this forum thread instead of creating a new thread: {{ account_questions_link }}
 
-4) Privacy policy: {{ request.scheme }}://{{ request.get_host }}{% url 'privacy_policy' %}
+4) Here is the privacy policy again for reference: {{ request.scheme }}://{{ request.get_host }}{% url 'privacy_policy' %}
 
 5) General information about CoralNet: {{ request.scheme }}://{{ request.get_host }}{% url 'about' %}
 

--- a/project/lib/templates/lib/privacy_policy.md
+++ b/project/lib/templates/lib/privacy_policy.md
@@ -1,5 +1,10 @@
 # CoralNet's Privacy Policy
 
+
+***Disclaimer:*** *This is not intended to serve as a legal document. This page informally describes the extent that various data on the website are considered private or not. We CoralNet administrators implement, follow, update, and communicate this policy with a best effort. We do this with the motivations of treating research communities with respect and providing a service that people will want to use. However, we do not have the resources or legal framework to make formal guarantees about keeping private data private. Your usage of this website is at your own risk.*
+
+-----
+
 We at CoralNet highly encourage public sharing of research data for the greater good. However, we realize that data privacy is preferred in some cases, especially for newer projects. So, sources have two visibility options, Public or Private.
 
 


### PR DESCRIPTION
PR #643 risks making the privacy policy look like a formal, legally-binding document like larger sites' privacy policies.

This PR adds a disclaimer at the top of the policy to address that:

> ***Disclaimer:*** *This is not intended to serve as a legal document. This page informally describes the extent that various data on the website are considered private or not. We CoralNet administrators implement, follow, update, and communicate this policy with a best effort. We do this with the motivations of treating research communities with respect and providing a service that people will want to use. However, we do not have the resources or legal framework to make formal guarantees about keeping private data private. Your usage of this website is at your own risk.*