### PR TITLE
Prev/next image logic speedups

### DIFF
--- a/project/annotations/views.py
+++ b/project/annotations/views.py
@@ -26,8 +26,8 @@ from images.utils import (
     generate_points,
     get_date_and_aux_metadata_table,
     get_image_order_placement,
-    get_next_image,
-    get_prev_image,
+    get_next_object,
+    get_prev_object,
 )
 from lib.decorators import (
     image_annotation_area_must_be_editable,
@@ -243,8 +243,8 @@ def annotation_tool(request, image_id):
         }
 
     # Get the next and previous images in the image set.
-    prev_image = get_prev_image(image, image_set, wrap=True)
-    next_image = get_next_image(image, image_set, wrap=True)
+    prev_image = get_prev_object(image, image_set, wrap=True)
+    next_image = get_next_object(image, image_set, wrap=True)
     # Get the image's ordered placement in the image set, e.g. 5th.
     image_set_order_placement = get_image_order_placement(image, image_set)
 

--- a/project/images/tests/test_image_detail.py
+++ b/project/images/tests/test_image_detail.py
@@ -6,8 +6,9 @@ from bs4 import BeautifulSoup
 from django.urls import reverse
 
 from annotations.model_utils import AnnotationArea
-from lib.tests.utils import BasePermissionTest, ClientTest
+from lib.tests.utils import BasePermissionTest, ClientTest, scrambled_run
 from ..model_utils import PointGen
+from ..models import Image
 
 
 class PermissionTest(BasePermissionTest):
@@ -78,35 +79,43 @@ class ImageDetailTest(ClientTest):
         self.assertStatusOK(response)
 
     def test_prev_next_links(self):
-        img1 = self.upload_image(
-            self.user, self.source, image_options=dict(filename='1.png'))
-        img2 = self.upload_image(
-            self.user, self.source, image_options=dict(filename='2.png'))
-        img3 = self.upload_image(
-            self.user, self.source, image_options=dict(filename='3.png'))
+        def f1(*_args):
+            return self.upload_image(
+                self.user, self.source, image_options=dict(filename='1.png'))
+        def f2(*_args):
+            return self.upload_image(
+                self.user, self.source, image_options=dict(filename='2.png'))
+        def f3(*_args):
+            return self.upload_image(
+                self.user, self.source, image_options=dict(filename='3.png'))
+        # Ensure order by name and order by pk would be different permutations.
+        scrambled_run([f1, f2, f3])
+        pk1 = Image.objects.get(metadata__name='1.png').pk
+        pk2 = Image.objects.get(metadata__name='2.png').pk
+        pk3 = Image.objects.get(metadata__name='3.png').pk
 
         self.client.force_login(self.user)
 
         # Prev/next follows alphabetical order by name. So order is 1 > 2 > 3.
 
-        response = self.client.get(reverse('image_detail', args=[img1.pk]))
+        response = self.client.get(reverse('image_detail', args=[pk1]))
         self.assertInHTML(
             '| <a href="{}" title="2.png"> Next &gt;</a>'.format(
-                reverse('image_detail', args=[img2.pk])),
+                reverse('image_detail', args=[pk2])),
             response.content.decode())
 
-        response = self.client.get(reverse('image_detail', args=[img2.pk]))
+        response = self.client.get(reverse('image_detail', args=[pk2]))
         self.assertInHTML(
             '<a href="{}" title="1.png"> &lt; Previous</a>'
             ' | <a href="{}" title="3.png"> Next &gt;</a>'.format(
-                reverse('image_detail', args=[img1.pk]),
-                reverse('image_detail', args=[img3.pk])),
+                reverse('image_detail', args=[pk1]),
+                reverse('image_detail', args=[pk3])),
             response.content.decode())
 
-        response = self.client.get(reverse('image_detail', args=[img3.pk]))
+        response = self.client.get(reverse('image_detail', args=[pk3]))
         self.assertInHTML(
             '<a href="{}" title="2.png"> &lt; Previous</a>'.format(
-                reverse('image_detail', args=[img2.pk])),
+                reverse('image_detail', args=[pk2])),
             response.content.decode())
 
     def test_point_gen_method_text(self):

--- a/project/images/utils.py
+++ b/project/images/utils.py
@@ -2,7 +2,8 @@ import datetime
 import random
 
 from django.conf import settings
-from django.db.models import Count, Q
+from django.db.models import Count, Expression, F, OrderBy, Q, Value
+from django.db.models.lookups import Exact, GreaterThan, IsNull, LessThan
 
 from accounts.utils import get_alleviate_user
 from annotations.model_utils import AnnotationArea
@@ -29,43 +30,59 @@ def find_dupe_image(source, image_name):
         return metadata.image
 
 
-def _get_next_images_queryset(current_image, image_queryset):
+def _get_next_objects_queryset(current_object, queryset):
     """
-    Get the images that are ordered after current_image, based on the
+    Get the object that are ordered after current_object, based on the
     queryset's ordering.
     """
+    queryset_model_class = queryset.model
+    assert isinstance(
+        current_object, queryset_model_class), "Don't mix and match models"
+
     # Start this Q object out as 'always False' because we want to make this
     # the starting value of an 'OR' reduce chain.
-    # From: https://stackoverflow.com/questions/35893867/
-    filter_q = Q(pk__in=[])
+    filter_q = Q(Value(False))
     # Start this Q object out as 'always True' because we want to make this
     # the starting value of an 'AND' reduce chain.
-    # From: https://stackoverflow.com/questions/33517468/
-    previous_keys_equal_q = ~Q(pk__in=[])
+    previous_args_equal_q = Q(Value(True))
 
     # query.order_by example: ['metadata__name', 'pk']
     #
     # The query we want gets more complicated depending on the number of
-    # order_by keys:
-    # 1 key: key1 greater
-    # 2 keys: key1 greater OR (key1 equal AND key2 greater)
-    # 3 keys: key1 greater OR (key1 equal AND key2 greater)
-    #   OR (key1 equal AND key2 equal AND key3 greater)
+    # order_by args:
+    # 1 arg: arg1 greater
+    # 2 args: arg1 greater OR (arg1 equal AND arg2 greater)
+    # 3 args: arg1 greater OR (arg1 equal AND arg2 greater)
+    #   OR (arg1 equal AND arg2 equal AND arg3 greater)
     # Etc.
-    for ordering_key in image_queryset.query.order_by:
+    for ordering_arg in queryset.query.order_by:
 
-        descending = ordering_key.startswith('-')
-        if not image_queryset.query.standard_ordering:
+        if isinstance(ordering_arg, Expression):
+            if isinstance(ordering_arg, OrderBy):
+                # OrderBy Expression
+                descending = ordering_arg.descending
+                ordering_expr = ordering_arg.expression
+            else:
+                # Other Expression
+                descending = False
+                ordering_expr = ordering_arg
+        else:
+            # str
+            descending = ordering_arg.startswith('-')
+            ordering_field = ordering_arg.lstrip('-')
+            # Convert to Expression
+            ordering_expr = F(ordering_field)
+
+        if not queryset.query.standard_ordering:
             # The queryset's reverse() method was called.
             descending = not descending
 
-        field_name = ordering_key.lstrip('-')
+        current_object_ordering_value = (
+            queryset_model_class.objects.filter(pk=current_object.pk)
+            .values_list(ordering_expr, flat=True)[0]
+        )
 
-        current_image_ordering_value = \
-            Image.objects.filter(pk=current_image.pk) \
-            .values_list(field_name, flat=True)[0]
-
-        if current_image_ordering_value is None:
+        if current_object_ordering_value is None:
             # Nullable fields have a complication: we can't specify
             # `...__gt=None` as a filter kwarg. That gets
             # `ValueError: Cannot use None as a query value`.
@@ -74,68 +91,73 @@ def _get_next_images_queryset(current_image, image_queryset):
             # values, and 'less than None' means all non-None values.
             if descending:
                 # 'less than None' (all non-None values)
-                current_key_after_q = Q(**{field_name + '__isnull': False})
+                current_arg_after_q = Q(IsNull(ordering_expr, False))
             else:
                 # 'greater than None' (always False)
-                current_key_after_q = Q(pk__in=[])
+                current_arg_after_q = Q(Value(False))
+
+            current_arg_equal_q = Q(IsNull(ordering_expr, True))
         else:
             if descending:
                 # 'less than current value'
-                current_key_after_q = Q(**{
-                    field_name + '__lt': current_image_ordering_value})
+                current_arg_after_q = Q(
+                    LessThan(ordering_expr, current_object_ordering_value))
             else:
                 # 'greater than current value' (greater value or None)
-                current_key_after_q = (
-                    Q(**{field_name + '__gt': current_image_ordering_value})
+                current_arg_after_q = (
+                    Q(GreaterThan(ordering_expr, current_object_ordering_value))
                     |
-                    Q(**{field_name + '__isnull': True}))
+                    Q(IsNull(ordering_expr, True)))
 
-        filter_q = filter_q | (previous_keys_equal_q & current_key_after_q)
+            current_arg_equal_q = Q(
+                Exact(ordering_expr, current_object_ordering_value))
 
-        previous_keys_equal_q = previous_keys_equal_q & Q(
-            **{field_name: current_image_ordering_value})
+        filter_q = filter_q | (previous_args_equal_q & current_arg_after_q)
 
-    return image_queryset.filter(filter_q)
+        previous_args_equal_q = previous_args_equal_q & current_arg_equal_q
+
+    return queryset.filter(filter_q)
 
 
-def get_next_image(current_image, image_queryset, wrap=False):
+def get_next_object(current_object, queryset, wrap=False):
     """
-    Get the next image in the image_queryset, relative to current_image.
-    image_queryset should already be ordered, with an unambiguous ordering
+    Get the next object in the queryset, relative to current_object.
+    queryset should already be ordered, with an unambiguous ordering
     (no ties).
 
     If wrap is True, then the definition of 'next' is extended to allow
-    wrapping from the last image to the first.
+    wrapping from the last object to the first.
 
-    If there is no next image, return None.
+    If there is no next object, return None.
     """
-    if image_queryset.count() <= 1:
-        return None
+    next_objects = _get_next_objects_queryset(current_object, queryset)
 
-    next_images = _get_next_images_queryset(current_image, image_queryset)
-
-    if next_images.exists():
-        return next_images[0]
+    if next_objects.exists():
+        return next_objects[0]
     elif wrap:
-        # No matching images after this image,
-        # so we wrap around to the first image.
-        return image_queryset[0]
+        # No matching objects after this object, so we wrap around
+        # to the first object. Assuming we're not AT the first object.
+        first_object = queryset[0]
+        if first_object.pk == current_object.pk:
+            return None
+        else:
+            return first_object
     else:
-        # No matching images after this image, and we're not allowed to wrap.
+        # No matching objects after this object, and we're not allowed to wrap.
         return None
 
 
-def get_prev_image(current_image, image_queryset, wrap=False):
+def get_prev_object(current_object, queryset, wrap=False):
     """
-    Get the previous image in the image_queryset, relative to current_image.
+    Get the previous object in the queryset, relative to current_object.
     """
-    # Finding the previous image is equivalent to
-    # finding the next image in the reverse queryset.
-    return get_next_image(current_image, image_queryset.reverse(), wrap)
+    # Finding the previous object is equivalent to
+    # finding the next object in the reverse queryset.
+    return get_next_object(current_object, queryset.reverse(), wrap)
 
 
 def get_image_order_placement(current_image, image_queryset):
-    prev_images = _get_next_images_queryset(
+    prev_images = _get_next_objects_queryset(
         current_image, image_queryset.reverse())
 
     # e.g. if there's 4 images that are ordered before the current image,

--- a/project/images/views.py
+++ b/project/images/views.py
@@ -1,4 +1,5 @@
 from django.contrib import messages
+from django.db.models.functions import Lower
 from django.http import HttpResponseRedirect
 from django.shortcuts import render, get_object_or_404
 from django.urls import reverse
@@ -57,16 +58,17 @@ def image_detail(request, image_id):
         thumbnail_dimensions = False
 
     # Next and previous image links.
-    # Ensure the ordering is unambiguous.
-    source_images = source.image_set.order_by('metadata__name')
-    next_image = utils.get_next_image(image, source_images, wrap=False)
-    prev_image = utils.get_prev_image(image, source_images, wrap=False)
+    # This ordering should be unambiguous, and should take advantage of
+    # Metadata indexes for performance.
+    source_mds = source.metadata_set.order_by(Lower('name'))
+    next_metadata = utils.get_next_object(metadata, source_mds, wrap=False)
+    prev_metadata = utils.get_prev_object(metadata, source_mds, wrap=False)
 
     return render(request, 'images/image_detail.html', {
         'source': source,
         'image': image,
-        'next_image': next_image,
-        'prev_image': prev_image,
+        'next_image': next_metadata.image if next_metadata else None,
+        'prev_image': prev_metadata.image if prev_metadata else None,
         'metadata': metadata,
         'image_meta_table': utils.get_date_and_aux_metadata_table(image),
         'other_fields': other_fields,

--- a/project/visualization/utils.py
+++ b/project/visualization/utils.py
@@ -7,8 +7,9 @@ from PIL import Image as PILImage
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.files.storage import default_storage
-from django.db.models import Q
+from django.db.models import Expression, Q
 import django.db.models.fields as model_fields
+from django.db.models.functions import Lower
 
 from accounts.utils import get_alleviate_user, get_imported_user, get_robot_user
 from images.models import Metadata
@@ -105,20 +106,31 @@ def image_search_kwargs_to_queryset(search_kwargs, source):
     elif sort_method == 'last_annotation_date':
         sort_fields = ['annoinfo__last_annotation__annotation_date', 'pk']
     elif sort_method == 'name':
-        # metadata__name is guaranteed unique for each image, so pk as a
-        # secondary isn't needed.
-        sort_fields = ['metadata__name']
+        # Lower('metadata__name') is guaranteed unique for each image, so pk as
+        # a secondary isn't needed.
+        # By matching the unique constraint and associated index, this should
+        # get good performance.
+        sort_fields = [Lower('metadata__name')]
     else:
         # 'upload_date'
         sort_fields = ['pk']
 
-    if sort_direction == 'asc':
-        sort_keys = sort_fields
-    else:
-        # 'desc'
-        sort_keys = ['-'+field for field in sort_fields]
+    sort_args = []
+    for field in sort_fields:
+        if isinstance(field, Expression):
+            if sort_direction == 'asc':
+                arg = field.asc()
+            else:
+                arg = field.desc()
+        else:
+            # str
+            if sort_direction == 'asc':
+                arg = field
+            else:
+                arg = '-' + field
+        sort_args.append(arg)
 
-    image_results = image_results.order_by(*sort_keys)
+    image_results = image_results.order_by(*sort_args)
 
     return image_results
 


### PR DESCRIPTION
1. Remove a frivolous count() call, where all we're trying to do is check whether the applicable queryset contains anything besides the current object. There's a much more lightweight way to check that.

2. Ensure the metadata-name DB index is used in the image-detail prev/next case at least. This is done by (i) operating on a Metadata queryset instead of an Image one, and (ii) by using Django query expressions to work with lowercase name (thus matching the DB index, which is a case-insensitive unique constraint). The annotation tool prev/next case (and Browse sorting) now also get (ii), but (i) will take more effort, so that's a future task.

In the process of 2, _get_next_images_queryset(), get_next_image(), and get_prev_image() have been generalized to support any model and not just Images (the functions have been renamed accordingly too), and generalized to take order-by Expressions and not just strings.

Incidentally, a bit of 'equal to null' comparison logic was apparently broken for a while, and has now been fixed (see the `current_arg_equal_q` part of _get_next_objects_queryset()). Not sure why that only got exposed by our tests now and not before.