### PR TITLE
Annotation tool: Explicitly specify image dimensions for drawImage()

### DIFF
--- a/project/annotations/static/js/AnnotationToolImageHelper.js
+++ b/project/annotations/static/js/AnnotationToolImageHelper.js
@@ -187,7 +187,17 @@ var AnnotationToolImageHelper = (function() {
         }
 
         // Redraw the source image.
-        imageCanvas.getContext("2d").drawImage(currentSourceImage.imgBuffer, 0, 0);
+        // https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/drawImage
+        imageCanvas.getContext("2d").drawImage(
+            currentSourceImage.imgBuffer,
+            // Canvas coordinates at which to place the top-left corner of
+            // the source image.
+            0, 0,
+            // The dimensions to draw the image in the canvas. In some cases,
+            // browsers have problems interpreting the scaling info from
+            // image metadata, so specifying dimensions explicitly here helps.
+            // See https://github.com/coralnet/coralnet/issues/658
+            currentSourceImage.width, currentSourceImage.height);
 
         // If processing parameters are neutral values, then we just need
         // the original image, so we're done.


### PR DESCRIPTION
For issue #658, regarding the annotation tool displaying certain images in only a tiny corner of the image area, due to EXIF values present. See that issue for details, mostly explained by @Virtlink.

The comment I added over the relevant code here isn't the greatest. I have a follow-up refactoring PR ready with a better summary comment:

> In some cases, browsers use the dimensions given in EXIF when displaying an image, per the HTML spec. However, it doesn't make sense for the annotation tool to respect these EXIF dimensions: the canvas is already being scaled to the annotation tool's interactable area. So, here we specify our preferred image dimensions explicitly, favoring the pixel-data dims over the EXIF dims.