### PR TITLE
Annotation tool: Image helper module tested and mostly modernized

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -77,6 +77,11 @@ SECRET_KEY=
 # whatever reason, then use this.
 #HUEY_CONSUMER_PERIODIC=False
 
+
+#
+# Other settings related to testing/debugging
+#
+
 # Sometimes you want to run your development server with the ``DEBUG = False``
 # setting to test something - for example, the 404 and 500 error pages.
 # If so:
@@ -102,6 +107,37 @@ SECRET_KEY=
 # have force_debug_cursor set as described in settings.py.
 # Useful when debugging database-querying code.
 #LOG_DATABASE_QUERIES=True
+
+# If you're running the Selenium tests, you'll have to specify the browsers
+# on your system which Selenium can run on. Tests will run faster on headless
+# browsers.
+# This is a JSON array of hashes. Unfortunately it all has to be typed on one
+# line, because django-environ only seems to support single-line settings in
+# .env. If on Windows, be sure to type paths with forward slashes.
+# Each hash supports the following keys:
+#
+# name
+#   (Required) Name of the browser. Not case sensitive.
+#   Supported: 'Firefox', 'Chrome', 'Edge'.
+# webdriver
+#   Absolute path to the web driver program, such as geckodriver.exe for
+#   Firefox on Windows. If not specified, it searches your PATH for the
+#   web driver.
+# browser_binary
+#   Absolute path to the browser binary, such as firefox.exe for Firefox
+#   on Windows. If not specified, it looks on your PATH or your Windows
+#   registry.
+# cli_args
+#   Command line arguments used when starting the browser. Defaults to
+#   no arguments.
+#   The headless argument is particularly useful since it means
+#   an actual browser window doesn't show up during tests,
+#   so the tests run a little faster and stay in the background without
+#   interrupting anything else you're doing.
+#SELENIUM_BROWSERS=[{"name": "Firefox", "webdriver": "C:/Webdrivers/geckodriver.exe", "browser_binary": "C:/FirefoxPortable/default/App/firefox64/firefox.exe", "cli_args": ["-headless"]}, {"name": "Chrome", "webdriver": "C:/Webdrivers/chromedriver.exe", "cli_args": ["--headless"]}]
+
+# Debugging options for Javascript modules.
+#JAVASCRIPT_DEBUGGING={"AnnotationToolImageHelper": {"useDummyScaledImage": true, "fullImageDelaySeconds": 5}}
 
 
 #
@@ -131,34 +167,6 @@ SECRET_KEY=
 
 # Dark color scheme.
 #DARK_COLORS_AVAILABLE=True
-
-# If you're running the Selenium tests, you'll have to specify the browsers
-# on your system which Selenium can run on. Tests will run faster on headless
-# browsers.
-# This is a JSON array of hashes. Unfortunately it all has to be typed on one
-# line, because django-environ only seems to support single-line settings in
-# .env. If on Windows, be sure to type paths with forward slashes.
-# Each hash supports the following keys:
-#
-# name
-#   (Required) Name of the browser. Not case sensitive.
-#   Supported: 'Firefox', 'Chrome', 'Edge'.
-# webdriver
-#   Absolute path to the web driver program, such as geckodriver.exe for
-#   Firefox on Windows. If not specified, it searches your PATH for the
-#   web driver.
-# browser_binary
-#   Absolute path to the browser binary, such as firefox.exe for Firefox
-#   on Windows. If not specified, it looks on your PATH or your Windows
-#   registry.
-# cli_args
-#   Command line arguments used when starting the browser. Defaults to
-#   no arguments.
-#   The headless argument is particularly useful since it means
-#   an actual browser window doesn't show up during tests,
-#   so the tests run a little faster and stay in the background without
-#   interrupting anything else you're doing.
-#SELENIUM_BROWSERS=[{"name": "Firefox", "webdriver": "C:/Webdrivers/geckodriver.exe", "browser_binary": "C:/FirefoxPortable/default/App/firefox64/firefox.exe", "cli_args": ["-headless"]}, {"name": "Chrome", "webdriver": "C:/Webdrivers/chromedriver.exe", "cli_args": ["--headless"]}]
 
 
 #

--- a/project/annotations/forms.py
+++ b/project/annotations/forms.py
@@ -15,12 +15,17 @@ from django.forms.fields import (
 )
 from django.forms.models import ModelForm
 from django.forms.widgets import (
-    CheckboxSelectMultiple, HiddenInput, NumberInput, RadioSelect, TextInput)
+    CheckboxSelectMultiple,
+    HiddenInput,
+    NumberInput,
+    RadioSelect,
+    TextInput,
+)
 
 from accounts.utils import is_robot_user
 from images.models import Metadata, Point
 from labels.models import LocalLabel
-from lib.forms import EnhancedMultiWidget
+from lib.forms import EnhancedMultiWidget, RowsFormRenderer
 from visualization.forms import ResultCountForm
 from .model_utils import AnnotationArea
 from .models import Annotation, AnnotationToolSettings
@@ -117,9 +122,26 @@ class AnnotationToolSettingsForm(ModelForm):
             field.widget.attrs.update({'class': 'jscolor'})
 
 
+class SliderInput(NumberInput):
+    input_type = "range"
+    template_name = "django/forms/widgets/input.html"
+
+
 class AnnotationImageOptionsForm(Form):
+
     brightness = IntegerField(initial=0, min_value=-100, max_value=100)
+    brightness_slider = IntegerField(
+        initial=0, min_value=-100, max_value=100,
+        # This slider will sit right under the corresponding text field, so it
+        # doesn't need a separate label. Instead use a title for accessibility.
+        widget=SliderInput(attrs=dict(title="Brightness")), label="")
+
     contrast = IntegerField(initial=0, min_value=-100, max_value=100)
+    contrast_slider = IntegerField(
+        initial=0, min_value=-100, max_value=100,
+        widget=SliderInput(attrs=dict(title="Contrast")), label="")
+
+    default_renderer = RowsFormRenderer
 
 
 class AnnotationAreaPercentsWidget(EnhancedMultiWidget):

--- a/project/annotations/static/css/annotation_tool.css
+++ b/project/annotations/static/css/annotation_tool.css
@@ -255,14 +255,18 @@ td.annotationFormLabelCell {
 #image-tools-wrapper label {
     width: auto;
 }
-#image-tools-wrapper input {
+/* Text fields */
+#image-tools-wrapper input[type="number"] {
     margin: 1px 0;
     padding: 1px 1px;
 
     width: 48px;
 }
-
-/* Place for "Applying..." text for image options/tools form */
+/* Sliders */
+#image-tools-wrapper input[type="range"] {
+    width: 130px;
+}
+/* Place for "Applying..." text */
 #applyingText {
     display: inline-block;
 
@@ -303,10 +307,4 @@ td.annotationFormLabelCell {
 .ui-autocomplete.semi-transparent .ui-menu-item .ui-widget-content .ui-state-focus,
 .ui-autocomplete.semi-transparent .ui-menu-item .ui-widget-header .ui-state-focus {
     background: rgba(255,255,255,1.0);
-}
-
-/* jQuery-UI sliders. */
-.ui-slider {
-    width: 130px;
-    display: inline-block;
 }

--- a/project/annotations/static/js/AnnotationToolHelper.js
+++ b/project/annotations/static/js/AnnotationToolHelper.js
@@ -7,6 +7,9 @@ var AnnotationToolHelper = (function() {
     var saveAnnotationsUrl = null;
     var isAnnotationAllDoneUrl = null;
 
+    // Helper instances
+    var imageHelper = null;
+
     // HTML elements
     var annotationArea = null;
     var annotationList = null;
@@ -119,7 +122,7 @@ var AnnotationToolHelper = (function() {
     //
 
     function getImageCanvas() {
-        return AnnotationToolImageHelper.getImageCanvas();
+        return imageHelper.imageCanvas;
     }
 
     /*
@@ -1400,7 +1403,8 @@ var AnnotationToolHelper = (function() {
 
         /* Params:
          * fullHeight, fullWidth, IMAGE_AREA_WIDTH, IMAGE_AREA_HEIGHT,
-         * imagePoints, labels, machineSuggestions */
+         * imagePoints, labels, machineSuggestions,
+         * saveAnnotationsUrl, isAnnotationAllDoneUrl, imageHelper */
         init: function(params) {
             var i, j, n;    // Loop variables...
 
@@ -1408,6 +1412,10 @@ var AnnotationToolHelper = (function() {
 
             saveAnnotationsUrl = params.saveAnnotationsUrl;
             isAnnotationAllDoneUrl = params.isAnnotationAllDoneUrl;
+
+            /* Helpers */
+
+            imageHelper = params.imageHelper;
 
             /*
              * Initialize styling, sizing, and positioning for various elements

--- a/project/annotations/static/js/AnnotationToolImageHelper.js
+++ b/project/annotations/static/js/AnnotationToolImageHelper.js
@@ -1,25 +1,111 @@
-var AnnotationToolImageHelper = (function() {
+class AnnotationToolImageHelper {
 
-    var $resetButton = null;
-    var $applyingText = null;
+    get brightnessField() {
+        return document.getElementById('id_brightness');
+    }
+    get contrastField() {
+        return document.getElementById('id_contrast');
+    }
 
-    var brightnessField = null;
-    var contrastField = null;
-    var MIN_BRIGHTNESS = null;
-    var MAX_BRIGHTNESS = null;
-    var MIN_CONTRAST = null;
-    var MAX_CONTRAST = null;
+    get MIN_BRIGHTNESS() {
+        return Number(this.brightnessField.min);
+    }
+    get MAX_BRIGHTNESS() {
+        return Number(this.brightnessField.max);
+    }
+    get MIN_CONTRAST() {
+        return Number(this.contrastField.min);
+    }
+    get MAX_CONTRAST() {
+        return Number(this.contrastField.max);
+    }
 
-    var sourceImages = {};
-    var currentSourceImage = null;
-    var imageCanvas = null;
+    get imageCanvas() {
+        return document.getElementById('imageCanvas');
+    }
+    get resetButton() {
+        return document.getElementById('resetImageOptionsButton');
+    }
+    get applyingText() {
+        return document.getElementById('applyingText');
+    }
 
-    var nowApplyingProcessing = false;
-    var redrawSignal = false;
+    currentSourceImage = null;
+    nowApplyingProcessing = false;
+    redrawSignal = false;
 
+    constructor(sourceImagesArg) {
 
-    function resetImageExifOrientation(imageAsString) {
-        var exifObj;
+        // http://api.jqueryui.com/slider/
+        this.$brightnessSlider = $('#brightness_slider').slider({
+            value: Number(this.brightnessField.value),
+            min: this.MIN_BRIGHTNESS,
+            max: this.MAX_BRIGHTNESS,
+            step: 1,
+            slide: this.onBrightnessSlider.bind(this),
+            // When the slider value is changed, either by the user
+            // directly or a programmatic change, re-draw the source image
+            // and re-apply bri/con operations.
+            change: this.redrawImage.bind(this),
+        });
+        this.$contrastSlider = $('#contrast_slider').slider({
+            value: Number(this.contrastField.value),
+            min: this.MIN_CONTRAST,
+            max: this.MAX_CONTRAST,
+            step: 1,
+            slide: this.onContrastSlider.bind(this),
+            change: this.redrawImage.bind(this),
+        });
+
+        this.brightnessField.addEventListener(
+            'change', this.onBrightnessText.bind(this));
+        this.contrastField.addEventListener(
+            'change', this.onContrastText.bind(this));
+
+        this.resetButton.addEventListener(
+            'click', this.resetBriCon.bind(this));
+
+        this.sourceImages = sourceImagesArg;
+    }
+
+    /*
+    When the slider is moved (by the user), update the text field too.
+    */
+    onBrightnessSlider(event, ui) {
+        this.brightnessField.value = ui.value;
+    }
+    onContrastSlider(event, ui) {
+        this.contrastField.value = ui.value;
+    }
+
+    /*
+    When the text fields are updated (by the user), update the sliders too.
+    */
+    onBrightnessText(event) {
+        let field = event.target;
+        // If the browser supports the "number" input type, with
+        // validity checking and all, then return if invalid.
+        if (field.validity && !field.validity.valid) { return; }
+        // If value box is empty, return.
+        if (field.value === '') { return; }
+        this.$brightnessSlider.slider('value', Number(field.value));
+    }
+    onContrastText(event) {
+        let field = event.target;
+        if (field.validity && !field.validity.valid) { return; }
+        if (field.value === '') { return; }
+        this.$contrastSlider.slider('value', Number(field.value));
+    }
+
+    async loadSourceImages() {
+        if (this.sourceImages.hasOwnProperty('scaled')) {
+            await this.loadSourceImage('scaled');
+        }
+        await this.loadSourceImage('full');
+    }
+
+    resetImageExifOrientation(imageAsString) {
+        let exifObj;
 
         try {
             exifObj = piexif.load(imageAsString);
@@ -48,18 +134,17 @@ var AnnotationToolImageHelper = (function() {
                     }
                     else {
                         alert(
-                            "Error when loading the image: \"" + e.message
-                            + "\" If the problem persists,"
-                            + " please contact the admins.");
+                            `Error when setting up the image: "${e.message}"`
+                            + " \nIf the problem persists,"
+                            + " please notify the admins.");
                         throw e;
                     }
                 }
             }
             else {
                 alert(
-                    "Error when loading the image: \"" + e.message
-                    + "\" If the problem persists,"
-                    + " please contact the admins.");
+                    `Error when loading the image: "${e.message}"`
+                    + " \nIf the problem persists, please notify the admins.");
                 throw e;
             }
         }
@@ -67,40 +152,27 @@ var AnnotationToolImageHelper = (function() {
         // If we're here, we successfully read the exif.
         // Set the orientation tag to the default value.
         exifObj['0th'][piexif.ImageIFD.Orientation] = 1;
-        var editedExifStr = piexif.dump(exifObj);
+        let editedExifStr = piexif.dump(exifObj);
         return piexif.insert(editedExifStr, imageAsString);
     }
 
-    /* Preload a source image; once it's loaded, swap it in as the image
-     * used in the annotation tool.
-     *
-     * Parameters:
-     * code - Which version of the image it is: 'scaled' or 'full'.
-     *
-     * Basic code pattern from: http://stackoverflow.com/a/1662153/
-     */
-    function preloadAndUseSourceImage(code) {
+    /*
+    Load a source image, and swap it in as the image used in the
+    annotation tool.
+
+    Parameters:
+    code - Which version of the image it is: 'scaled' or 'full'.
+
+    Basic code pattern from: http://stackoverflow.com/a/1662153/
+    */
+    async loadSourceImage(code) {
         // Create an Image object.
-        sourceImages[code].imgBuffer = new Image();
+        this.sourceImages[code].imgBuffer = new Image();
+        let imgBuffer = this.sourceImages[code].imgBuffer;
 
         // Allow the image to be from a different domain such as S3.
         // https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image
-        sourceImages[code].imgBuffer.crossOrigin = "Anonymous";
-
-        // When image preloading is done, swap images.
-        sourceImages[code].imgBuffer.onload = function() {
-            imageCanvas.width = sourceImages[code].width;
-            imageCanvas.height = sourceImages[code].height;
-
-            currentSourceImage = sourceImages[code];
-            redrawImage();
-
-            // If we just finished loading the scaled image, then start loading
-            // the full image.
-            if (code === 'scaled') {
-                preloadAndUseSourceImage('full');
-            }
-        };
+        imgBuffer.crossOrigin = "Anonymous";
 
         // Download image from URL. Normally setting a DOM Image's src
         // attribute to the URL is a 'shortcut' for doing this, but:
@@ -112,84 +184,102 @@ var AnnotationToolImageHelper = (function() {
         // 2. The Image src route could require an intermediate usage of
         // Canvas.toDataURL(), which would re-encode the image (thus applying
         // another round of JPEG compression, for example).
-        var imageRequest = new XMLHttpRequest();
-        imageRequest.open('GET', sourceImages[code].url, true);
-        imageRequest.responseType = 'arraybuffer';
+        let response = await fetch(this.sourceImages[code].url);
 
-        imageRequest.onload = function() {
-            var arrayBuffer = imageRequest.response;
-            if (!arrayBuffer) {
-                alert(
-                    "Error when loading the image: couldn't get arrayBuffer."
-                    + " If the problem persists, please contact the admins.");
-                return;
-            }
+        let imageAsBinaryString;
+        try {
+            let blob = await response.blob();
+            imageAsBinaryString = await this.readBlob(blob);
+        }
+        catch (e) {
+            alert(
+                `Error when retrieving the ${code} image: "${e.message}"`
+                + " \nIf the problem persists, please notify the admins.");
+            return;
+        }
 
-            var blob = new Blob([arrayBuffer]);
-            var reader = new FileReader();
+        // Reset the image's EXIF orientation tag to the default value,
+        // so that the browser can't pick up the EXIF orientation and
+        // rotate the displayed image accordingly.
+        //
+        // Perhaps later, we'll give an option to respect the EXIF
+        // orientation here. But it must be done properly, rotating
+        // the point positions as well as the image itself.
+        //
+        // This overall approach of EXIF-editing may not be necessary
+        // in the future, if canvas elements respect the CSS
+        // image-orientation attribute or similar:
+        // https://image-orientation-test.now.sh/
+        let exifEditedDataString =
+            this.resetImageExifOrientation(imageAsBinaryString);
 
-            reader.onload = function(event) {
+        // Convert the data string to a base64 URL.
+        let contentType = response.headers.get('content-type');
+        let exifEditedDataURL = (
+            "data:" + contentType
+            + ";base64," + btoa(exifEditedDataString));
 
-                // Reset the image's EXIF orientation tag to the default value,
-                // so that the browser can't pick up the EXIF orientation and
-                // rotate the displayed image accordingly.
-                //
-                // Perhaps later, we'll give an option to respect the EXIF
-                // orientation here. But it must be done properly, rotating
-                // the point positions as well as the image itself.
-                //
-                // This overall approach of EXIF-editing may not be necessary
-                // in the future, if canvas elements respect the CSS
-                // image-orientation attribute or similar:
-                // https://image-orientation-test.now.sh/
-                var exifEditedDataString = resetImageExifOrientation(
-                    event.target.result);
-
-                // Convert the data string to a base64 URL.
-                var contentType = imageRequest.getResponseHeader(
-                    'content-type');
-                var exifEditedDataURL = (
-                    "data:" + contentType
-                    + ";base64," + btoa(exifEditedDataString));
-
-                // Load the EXIF-edited image into the image canvas.
-                sourceImages[code].imgBuffer.src = exifEditedDataURL;
-            };
-            reader.readAsBinaryString(blob);
-        };
-
-        imageRequest.send(null);
-
-        // For debugging, it sometimes helps to load an image that
-        // (1) has different image content, so you can tell when it's swapped in, and/or
+        // For debugging, it sometimes helps to load a full image that
+        // (1) has different image content, so you can tell when it's swapped
+        //     in, and/or
         // (2) is loaded after a delay, so you can zoom in first and then
         //     notice the resolution change when it happens.
-        // Here's (2) in action: uncomment the below code and comment out the
-        // preload line above to try it.  The second parameter to setTimeout()
-        // is milliseconds until the first-parameter function is called.
+        // Here's (2) in action: uncomment the below lines to try it.
         // NOTE: only use this for debugging, not for production.
-        //setTimeout(function() {
-        //    sourceImages[code].imgBuffer.src = sourceImages[code].url;
-        //}, 10000);
+        // if (code === 'full') {
+        //     const SECONDS = 5;
+        //     await new Promise(r => setTimeout(r, SECONDS * 1000));
+        // }
+
+        // Load the EXIF-edited image into the image canvas.
+        imgBuffer.src = exifEditedDataURL;
+
+        // Wait for image to load.
+        await imgBuffer.decode();
+
+        // Swap images.
+        this.imageCanvas.width = this.sourceImages[code].width;
+        this.imageCanvas.height = this.sourceImages[code].height;
+
+        this.currentSourceImage = this.sourceImages[code];
+        this.redrawImage();
+    }
+
+    readBlob(blob) {
+      return new Promise((resolve, reject) => {
+        let reader = new FileReader();
+
+        reader.onload = () => {
+          resolve(reader.result);
+        };
+
+        reader.onerror = reject;
+
+        // TODO: This method is deprecated. The challenge is that the format it
+        //  produces (binary string) is also pretty much deprecated in JS, and
+        //  piexif is an outdated library which pretty much depends on that
+        //  format. So it seems we need to replace piexif.
+        reader.readAsBinaryString(blob);
+      });
     }
 
     /* Redraw the source image, and apply brightness and contrast operations. */
-    function redrawImage() {
+    redrawImage() {
         // If we haven't loaded any image yet, don't do anything.
-        if (currentSourceImage === null)
+        if (this.currentSourceImage === null)
             return;
 
         // If processing is currently going on, emit the redraw signal to
         // tell it to stop processing and re-call this function.
-        if (nowApplyingProcessing === true) {
-            redrawSignal = true;
+        if (this.nowApplyingProcessing === true) {
+            this.redrawSignal = true;
             return;
         }
 
         // Redraw the source image.
         // https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/drawImage
-        imageCanvas.getContext("2d").drawImage(
-            currentSourceImage.imgBuffer,
+        this.imageCanvas.getContext("2d").drawImage(
+            this.currentSourceImage.imgBuffer,
             // Canvas coordinates at which to place the top-left corner of
             // the source image.
             0, 0,
@@ -197,11 +287,14 @@ var AnnotationToolImageHelper = (function() {
             // browsers have problems interpreting the scaling info from
             // image metadata, so specifying dimensions explicitly here helps.
             // See https://github.com/coralnet/coralnet/issues/658
-            currentSourceImage.width, currentSourceImage.height);
+            this.currentSourceImage.width, this.currentSourceImage.height);
 
         // If processing parameters are neutral values, then we just need
         // the original image, so we're done.
-        if (brightnessField.value === 0 && contrastField.value === 0) {
+        if (
+            this.brightnessField.value === 0
+            && this.contrastField.value === 0
+        ) {
             return;
         }
 
@@ -210,26 +303,26 @@ var AnnotationToolImageHelper = (function() {
            That way we don't lock up the browser for a really long
            time when processing a large image. */
 
-        var X_MAX = imageCanvas.width - 1;
-        var Y_MAX = imageCanvas.height - 1;
+        const X_MAX = this.imageCanvas.width - 1;
+        const Y_MAX = this.imageCanvas.height - 1;
 
-        var RECT_SIZE = 1400;
+        const RECT_SIZE = 1400;
 
-        var x1 = 0, y1 = 0, xRanges = [], yRanges = [];
+        let x1 = 0, y1 = 0, xRanges = [], yRanges = [];
         while (x1 <= X_MAX) {
-            var x2 = Math.min(x1 + RECT_SIZE - 1, X_MAX);
+            let x2 = Math.min(x1 + RECT_SIZE - 1, X_MAX);
             xRanges.push([x1, x2]);
             x1 = x2 + 1;
         }
         while (y1 <= Y_MAX) {
-            var y2 = Math.min(y1 + RECT_SIZE - 1, Y_MAX);
+            let y2 = Math.min(y1 + RECT_SIZE - 1, Y_MAX);
             yRanges.push([y1, y2]);
             y1 = y2 + 1;
         }
 
-        var rects = [];
-        for (var i = 0; i < xRanges.length; i++) {
-            for (var j = 0; j < yRanges.length; j++) {
+        let rects = [];
+        for (let i = 0; i < xRanges.length; i++) {
+            for (let j = 0; j < yRanges.length; j++) {
                 rects.push({
                     'left': xRanges[i][0],
                     'top': yRanges[j][0],
@@ -239,8 +332,8 @@ var AnnotationToolImageHelper = (function() {
             }
         }
 
-        nowApplyingProcessing = true;
-        $applyingText.css({'visibility': 'visible'});
+        this.nowApplyingProcessing = true;
+        this.applyingText.style.visibility = 'visible';
 
         // The user-defined brightness and contrast are applied as
         // 'bias' and 'gain' according to this formula:
@@ -248,21 +341,23 @@ var AnnotationToolImageHelper = (function() {
 
         // We'll say the bias can increase/decrease the pixel value by
         // as much as 150.
-        var brightness = Number(brightnessField.value);
-        var brightnessFraction =
-            (brightness - MIN_BRIGHTNESS) / (MAX_BRIGHTNESS - MIN_BRIGHTNESS);
-        var bias = (150*2)*brightnessFraction - 150;
+        let brightness = Number(this.brightnessField.value);
+        let brightnessFraction =
+            (brightness - this.MIN_BRIGHTNESS)
+            / (this.MAX_BRIGHTNESS - this.MIN_BRIGHTNESS);
+        let bias = (150*2)*brightnessFraction - 150;
 
         // We'll say the gain can multiply the pixel values by
         // a range of MIN_BIAS to MAX_BIAS.
         // The middle contrast value must map to 1.
-        var MIN_BIAS = 0.25;
-        var MAX_BIAS = 3.0;
-        var contrast = Number(contrastField.value);
-        var contrastFraction =
-            (contrast - MIN_CONTRAST) / (MAX_CONTRAST - MIN_CONTRAST);
-        var gain = null;
-        var gainFraction = null;
+        const MIN_BIAS = 0.25;
+        const MAX_BIAS = 3.0;
+        let contrast = Number(this.contrastField.value);
+        let contrastFraction =
+            (contrast - this.MIN_CONTRAST)
+            / (this.MAX_CONTRAST - this.MIN_CONTRAST);
+        let gain;
+        let gainFraction;
         if (contrastFraction > 0.5) {
             // Map 0.5~1.0 to 1.0~3.0
             gainFraction = (contrastFraction - 0.5) / (1.0 - 0.5);
@@ -274,18 +369,29 @@ var AnnotationToolImageHelper = (function() {
             gain = (1.0-MIN_BIAS)*gainFraction + MIN_BIAS;
         }
 
-        applyBriConToRemainingRects(gain, bias, rects);
+        this.applyBriConToRemainingRects(gain, bias, rects);
     }
 
-    function applyBriConToRect(gain, bias, data, numPixels) {
+    /*
+    Reset image processing parameters to default values,
+    and redraw the image.
+    */
+    resetBriCon() {
+        this.brightnessField.value = 0;
+        this.contrastField.value = 0;
+        this.$brightnessSlider.slider('value', 0);
+        this.$contrastSlider.slider('value', 0);
+        this.redrawImage();
+    }
+
+    applyBriConToRect(gain, bias, data, numPixels) {
         // Performance note: We tried having a curried function which was
         // called once for each pixel. However, this ended up taking 8-9
         // seconds for a 1400x1400 pixel rect, even if the function simply
         // returns immediately. (Firefox 50.0, 2016.11.28)
         // So the lesson is: function calls are usually cheap,
         // but don't underestimate using them by the million.
-        var px;
-        for (px = 0; px < numPixels; px++) {
+        for (let px = 0; px < numPixels; px++) {
             // 4 components per pixel, in RGBA order. We'll ignore alpha.
             data[4*px] = gain*data[4*px] + bias;
             data[4*px + 1] = gain*data[4*px + 1] + bias;
@@ -293,129 +399,46 @@ var AnnotationToolImageHelper = (function() {
         }
     }
 
-    function applyBriConToRemainingRects(gain, bias, rects) {
-        if (redrawSignal === true) {
-            nowApplyingProcessing = false;
-            redrawSignal = false;
-            $applyingText.css({'visibility': 'hidden'});
+    applyBriConToRemainingRects(gain, bias, rects) {
+        if (this.redrawSignal === true) {
+            this.nowApplyingProcessing = false;
+            this.redrawSignal = false;
+            this.applyingText.style.visibility = 'hidden';
 
-            redrawImage();
+            this.redrawImage();
             return;
         }
 
         // "Pop" the first element from rects.
-        var rect = rects.shift();
+        let rect = rects.shift();
 
         // Grab the rect from the image canvas.
-        var rectCanvasImageData = imageCanvas.getContext("2d")
+        let rectCanvasImageData = this.imageCanvas.getContext("2d")
             .getImageData(rect.left, rect.top, rect.width, rect.height);
 
         // Apply bri/con to the rect.
-        applyBriConToRect(
+        this.applyBriConToRect(
             gain, bias, rectCanvasImageData.data,
             rect['width']*rect['height']);
 
         // Put the post-bri/con data on the image canvas.
-        imageCanvas.getContext("2d").putImageData(
+        this.imageCanvas.getContext("2d").putImageData(
             rectCanvasImageData, rect.left, rect.top);
 
         if (rects.length > 0) {
             // Slightly delay the processing of the next rect, so we
             // don't lock up the browser for an extended period of time.
-            // Note the use of curry() to produce a function.
             setTimeout(
-                applyBriConToRemainingRects.curry(gain, bias, rects), 50
+                this.applyBriConToRemainingRects.bind(this, gain, bias, rects),
+                50,
             );
         }
         else {
-            nowApplyingProcessing = false;
-            $applyingText.css({'visibility': 'hidden'});
+            this.nowApplyingProcessing = false;
+            this.applyingText.style.visibility = 'hidden';
         }
     }
+}
 
 
-    /* Public methods.
-     * These are the only methods that need to be referred to as
-     * <SingletonClassName>.<methodName>. */
-    return {
-        init: function (sourceImagesArg) {
-            $resetButton = $('#resetImageOptionsButton');
-            $applyingText = $('#applyingText');
-
-            brightnessField = $('#id_brightness')[0];
-            contrastField = $('#id_contrast')[0];
-            MIN_BRIGHTNESS = Number(brightnessField.min);
-            MAX_BRIGHTNESS = Number(brightnessField.max);
-            MIN_CONTRAST = Number(contrastField.min);
-            MAX_CONTRAST = Number(contrastField.max);
-
-            // http://api.jqueryui.com/slider/
-            var $brightnessSlider = $('#brightness_slider').slider({
-                value: Number(brightnessField.value),
-                min: MIN_BRIGHTNESS,
-                max: MAX_BRIGHTNESS,
-                step: 1,
-                // When the slider is moved (by the user),
-                // update the text field too.
-                slide: function(event, ui) {
-                    brightnessField.value = ui.value;
-                },
-                // When the slider value is changed, either by the user
-                // directly or a programmatic change, re-draw the source image
-                // and re-apply bri/con operations.
-                change: redrawImage
-            });
-            var $contrastSlider = $('#contrast_slider').slider({
-                value: Number(contrastField.value),
-                min: MIN_CONTRAST,
-                max: MAX_CONTRAST,
-                step: 1,
-                slide: function(event, ui) {
-                    contrastField.value = ui.value;
-                },
-                change: redrawImage
-            });
-
-            // When the text fields are updated (by the user),
-            // update the sliders too.
-            brightnessField.addEventListener('change', function() {
-                // If the browser supports the "number" input type, with
-                // validity checking and all, then return if invalid.
-                if (this.validity && !this.validity.valid) { return; }
-                // If value box is empty, return.
-                if (this.value === '') { return; }
-                $brightnessSlider.slider('value', Number(this.value));
-            });
-            contrastField.addEventListener('change', function() {
-                if (this.validity && !this.validity.valid) { return; }
-                if (this.value === '') { return; }
-                $contrastSlider.slider('value', Number(this.value));
-            });
-
-            sourceImages = sourceImagesArg;
-
-            imageCanvas = $('#imageCanvas')[0];
-
-            if (sourceImages.hasOwnProperty('scaled')) {
-                preloadAndUseSourceImage('scaled');
-            }
-            else {
-                preloadAndUseSourceImage('full');
-            }
-
-            // When the Reset button is clicked, reset image processing
-            // parameters to default values, and redraw the image.
-            $resetButton.click(function () {
-                brightnessField.value = 0;
-                contrastField.value = 0;
-                $brightnessSlider.slider('value', 0);
-                $contrastSlider.slider('value', 0);
-                redrawImage();
-            });
-        },
-
-        getImageCanvas: function () {
-            return imageCanvas;
-        }
-    }
-})();
+export default AnnotationToolImageHelper;

--- a/project/annotations/static/js/AnnotationToolImageHelper.js
+++ b/project/annotations/static/js/AnnotationToolImageHelper.js
@@ -296,8 +296,8 @@ class AnnotationToolImageHelper {
         // If processing parameters are neutral values, then we just need
         // the original image, so we're done.
         if (
-            this.brightnessField.value === 0
-            && this.contrastField.value === 0
+            this.brightnessField.value === '0'
+            && this.contrastField.value === '0'
         ) {
             return;
         }

--- a/project/annotations/static/js/AnnotationToolImageHelper.js
+++ b/project/annotations/static/js/AnnotationToolImageHelper.js
@@ -110,7 +110,7 @@ class AnnotationToolImageHelper {
         await this.loadSourceImage('full');
     }
 
-    resetImageExifOrientation(imageAsString) {
+    static resetImageExifOrientation(imageAsString) {
         let exifObj;
 
         try {
@@ -181,7 +181,7 @@ class AnnotationToolImageHelper {
         imgBuffer.crossOrigin = "Anonymous";
 
         // Download image from URL. Normally setting a DOM Image's src
-        // attribute to the URL is a 'shortcut' for doing this, but:
+        // attribute to the URL is a 'shortcut' for loading the image, but:
         //
         // 1. Since we are concerned about EXIF orientation screwing up
         // dimensions assumptions, we want to edit the EXIF before loading the
@@ -190,10 +190,11 @@ class AnnotationToolImageHelper {
         // 2. The Image src route could require an intermediate usage of
         // Canvas.toDataURL(), which would re-encode the image (thus applying
         // another round of JPEG compression, for example).
-        let response = await fetch(this.sourceImages[code].url);
 
+        let response;
         let imageAsBinaryString;
         try {
+            response = await fetch(this.sourceImages[code].url);
             let blob = await response.blob();
             imageAsBinaryString = await this.constructor.readBlob(blob);
         }
@@ -217,7 +218,7 @@ class AnnotationToolImageHelper {
         // image-orientation attribute or similar:
         // https://image-orientation-test.now.sh/
         let exifEditedDataString =
-            this.resetImageExifOrientation(imageAsBinaryString);
+            this.constructor.resetImageExifOrientation(imageAsBinaryString);
 
         // Convert the data string to a base64 URL.
         let contentType = response.headers.get('content-type');

--- a/project/annotations/static/js/AnnotationToolImageHelper.js
+++ b/project/annotations/static/js/AnnotationToolImageHelper.js
@@ -273,6 +273,8 @@ class AnnotationToolImageHelper {
       });
     }
 
+    RECT_SIZE = 1400;
+
     /* Redraw the source image, and apply brightness and contrast operations. */
     redrawImage() {
         // If we haven't loaded any image yet, don't do anything.
@@ -322,16 +324,14 @@ class AnnotationToolImageHelper {
         const X_MAX = this.imageCanvas.width - 1;
         const Y_MAX = this.imageCanvas.height - 1;
 
-        const RECT_SIZE = 1400;
-
         let x1 = 0, y1 = 0, xRanges = [], yRanges = [];
         while (x1 <= X_MAX) {
-            let x2 = Math.min(x1 + RECT_SIZE - 1, X_MAX);
+            let x2 = Math.min(x1 + this.RECT_SIZE - 1, X_MAX);
             xRanges.push([x1, x2]);
             x1 = x2 + 1;
         }
         while (y1 <= Y_MAX) {
-            let y2 = Math.min(y1 + RECT_SIZE - 1, Y_MAX);
+            let y2 = Math.min(y1 + this.RECT_SIZE - 1, Y_MAX);
             yRanges.push([y1, y2]);
             y1 = y2 + 1;
         }

--- a/project/annotations/static/js/AnnotationToolImageHelper.js
+++ b/project/annotations/static/js/AnnotationToolImageHelper.js
@@ -40,7 +40,7 @@ class AnnotationToolImageHelper {
     nowApplyingProcessing = false;
     redrawSignal = false;
 
-    constructor(sourceImagesArg) {
+    constructor(sourceImagesArg, dummyScaledImage, debuggingOptions) {
 
         // Initialize value.
         this.brightnessSlider.value = this.brightnessField.value;
@@ -70,6 +70,8 @@ class AnnotationToolImageHelper {
             'click', this.resetBriCon.bind(this));
 
         this.sourceImages = sourceImagesArg;
+        this.dummyScaledImage = dummyScaledImage;
+        this.debugging = debuggingOptions || {};
     }
 
     updateBrightnessTextField(event) {
@@ -224,19 +226,22 @@ class AnnotationToolImageHelper {
             + ";base64," + btoa(exifEditedDataString));
 
         // For debugging, it sometimes helps to load a full image that
-        // (1) has different image content, so you can tell when it's swapped
-        //     in, and/or
-        // (2) is loaded after a delay, so you can zoom in first and then
-        //     notice the resolution change when it happens.
-        // Here's (2) in action: uncomment the below lines to try it.
-        // NOTE: only use this for debugging, not for production.
-        // if (code === 'full') {
-        //     const SECONDS = 5;
-        //     await new Promise(r => setTimeout(r, SECONDS * 1000));
-        // }
+        // is loaded after a delay, so you can zoom in first and then
+        // notice the resolution change when it happens.
+        if (this.debugging['fullImageDelaySeconds'] && code === 'full') {
+            const SECONDS = this.debugging['fullImageDelaySeconds'];
+            await new Promise(r => setTimeout(r, SECONDS * 1000));
+        }
 
-        // Load the EXIF-edited image into the image canvas.
-        imgBuffer.src = exifEditedDataURL;
+        // For debugging, it sometimes helps if the scaled image has different
+        // content entirely, so you can tell when the full image is swapped in.
+        if (this.debugging['useDummyScaledImage'] && code === 'scaled') {
+            imgBuffer.src = this.dummyScaledImage;
+        }
+        else {
+            // Load the EXIF-edited image into the image canvas.
+            imgBuffer.src = exifEditedDataURL;
+        }
 
         // Wait for image to load.
         await imgBuffer.decode();

--- a/project/annotations/static/js/AnnotationToolImageHelper.js
+++ b/project/annotations/static/js/AnnotationToolImageHelper.js
@@ -292,9 +292,15 @@ class AnnotationToolImageHelper {
             // Canvas coordinates at which to place the top-left corner of
             // the source image.
             0, 0,
-            // The dimensions to draw the image in the canvas. In some cases,
-            // browsers have problems interpreting the scaling info from
-            // image metadata, so specifying dimensions explicitly here helps.
+            // The dimensions to draw the image in the canvas.
+            //
+            // In some cases, browsers use the dimensions given in EXIF when
+            // displaying an image, per the HTML spec. However, it doesn't
+            // make sense for the annotation tool to respect these EXIF
+            // dimensions: the canvas is already being scaled to the annotation
+            // tool's interactable area. So, here we specify our preferred
+            // image dimensions explicitly, favoring the pixel-data dims over
+            // the EXIF dims.
             // See https://github.com/coralnet/coralnet/issues/658
             this.currentSourceImage.width, this.currentSourceImage.height);
 

--- a/project/annotations/static/js/AnnotationToolImageHelper.js
+++ b/project/annotations/static/js/AnnotationToolImageHelper.js
@@ -6,6 +6,12 @@ class AnnotationToolImageHelper {
     get contrastField() {
         return document.getElementById('id_contrast');
     }
+    get brightnessSlider() {
+        return document.getElementById('id_brightness_slider');
+    }
+    get contrastSlider() {
+        return document.getElementById('id_contrast_slider');
+    }
 
     get MIN_BRIGHTNESS() {
         return Number(this.brightnessField.min);
@@ -36,27 +42,25 @@ class AnnotationToolImageHelper {
 
     constructor(sourceImagesArg) {
 
-        // http://api.jqueryui.com/slider/
-        this.$brightnessSlider = $('#brightness_slider').slider({
-            value: Number(this.brightnessField.value),
-            min: this.MIN_BRIGHTNESS,
-            max: this.MAX_BRIGHTNESS,
-            step: 1,
-            slide: this.onBrightnessSlider.bind(this),
-            // When the slider value is changed, either by the user
-            // directly or a programmatic change, re-draw the source image
-            // and re-apply bri/con operations.
-            change: this.redrawImage.bind(this),
-        });
-        this.$contrastSlider = $('#contrast_slider').slider({
-            value: Number(this.contrastField.value),
-            min: this.MIN_CONTRAST,
-            max: this.MAX_CONTRAST,
-            step: 1,
-            slide: this.onContrastSlider.bind(this),
-            change: this.redrawImage.bind(this),
-        });
+        // Initialize value.
+        this.brightnessSlider.value = this.brightnessField.value;
+        // While the slider is moved by the user, update the text field too.
+        this.brightnessSlider.addEventListener(
+            'input', this.updateBrightnessTextField.bind(this));
+        // When the slider is moved by the user and then released, redraw.
+        this.brightnessSlider.addEventListener(
+            'change', this.redrawImage.bind(this));
 
+        this.contrastSlider.value = this.contrastField.value;
+        this.contrastSlider.addEventListener(
+            'input', this.updateContrastTextField.bind(this));
+        this.contrastSlider.addEventListener(
+            'change', this.redrawImage.bind(this));
+
+        /*
+        When the text fields are updated by the user: check validity of
+        input, update the sliders too, and redraw.
+        */
         this.brightnessField.addEventListener(
             'change', this.onBrightnessText.bind(this));
         this.contrastField.addEventListener(
@@ -68,19 +72,13 @@ class AnnotationToolImageHelper {
         this.sourceImages = sourceImagesArg;
     }
 
-    /*
-    When the slider is moved (by the user), update the text field too.
-    */
-    onBrightnessSlider(event, ui) {
-        this.brightnessField.value = ui.value;
+    updateBrightnessTextField(event) {
+        this.brightnessField.value = event.target.value;
     }
-    onContrastSlider(event, ui) {
-        this.contrastField.value = ui.value;
+    updateContrastTextField(event) {
+        this.contrastField.value = event.target.value;
     }
 
-    /*
-    When the text fields are updated (by the user), update the sliders too.
-    */
     onBrightnessText(event) {
         let field = event.target;
         // If the browser supports the "number" input type, with
@@ -88,13 +86,19 @@ class AnnotationToolImageHelper {
         if (field.validity && !field.validity.valid) { return; }
         // If value box is empty, return.
         if (field.value === '') { return; }
-        this.$brightnessSlider.slider('value', Number(field.value));
+
+        this.brightnessSlider.value = Number(field.value);
+
+        this.redrawImage();
     }
     onContrastText(event) {
         let field = event.target;
         if (field.validity && !field.validity.valid) { return; }
         if (field.value === '') { return; }
-        this.$contrastSlider.slider('value', Number(field.value));
+
+        this.contrastSlider.value = Number(field.value);
+
+        this.redrawImage();
     }
 
     async loadSourceImages() {
@@ -379,8 +383,8 @@ class AnnotationToolImageHelper {
     resetBriCon() {
         this.brightnessField.value = 0;
         this.contrastField.value = 0;
-        this.$brightnessSlider.slider('value', 0);
-        this.$contrastSlider.slider('value', 0);
+        this.brightnessSlider.value = 0;
+        this.contrastSlider.value = 0;
         this.redrawImage();
     }
 

--- a/project/annotations/static/js/AnnotationToolImageHelper.js
+++ b/project/annotations/static/js/AnnotationToolImageHelper.js
@@ -195,7 +195,7 @@ class AnnotationToolImageHelper {
         let imageAsBinaryString;
         try {
             let blob = await response.blob();
-            imageAsBinaryString = await this.readBlob(blob);
+            imageAsBinaryString = await this.constructor.readBlob(blob);
         }
         catch (e) {
             alert(
@@ -254,7 +254,7 @@ class AnnotationToolImageHelper {
         this.redrawImage();
     }
 
-    readBlob(blob) {
+    static readBlob(blob) {
       return new Promise((resolve, reject) => {
         let reader = new FileReader();
 

--- a/project/annotations/static/js/tests/AnnotationToolImageQUnit.js
+++ b/project/annotations/static/js/tests/AnnotationToolImageQUnit.js
@@ -5,10 +5,14 @@ import AnnotationToolImageHelper from '/static/js/AnnotationToolImageHelper.js';
 import { useFixture } from '/static/js/test-utils.js';
 
 let imageHelper;
-let SCALED_WIDTH = 800;
-let SCALED_HEIGHT = 600;
-let FULL_WIDTH = 3200;
-let FULL_HEIGHT = 2400;
+// These numbers are from a specific example in this issue regarding
+// EXIF resolution detection:
+// https://github.com/coralnet/coralnet/issues/658
+// See "EXIF scaling" QUnit module below.
+let SCALED_WIDTH = 770;
+let SCALED_HEIGHT = 775;
+let FULL_WIDTH = 2568;
+let FULL_HEIGHT = 2583;
 
 
 function instantiate() {
@@ -46,21 +50,79 @@ function instantiateFullOnly() {
 }
 
 
+/*
+If you want to download a test's crafted image to check its contents manually,
+you can temporarily add a call to this function in the test code.
+It should pop up a standard download dialog.
+Credit: https://gist.github.com/philipstanislaus/c7de1f43b52531001412
+
+Once downloaded, you can check the EXIF data with a web tool like this:
+https://framebird.io/exif-metadata-viewer/jfif
+Or with Python, like this function that checks scaling data (uses Pillow):
+from PIL import Image
+from PIL.ExifTags import IFD
+def info(filepath):
+    with Image.open(filepath) as im:
+        exif = im.getexif()
+    ifd = exif.get_ifd(IFD.Exif)
+    print(f"Pixel data dimensions: {im.width} x {im.height}")
+    print(f"EXIF IFD PixelX/YDimension: {ifd.get(40962)} x {ifd.get(40963)}")
+    print(f"EXIF X/YResolution: {exif.get(282)} x {exif.get(283)}")
+    print(f"EXIF ResolutionUnit: {exif.get(296)}")
+*/
+function downloadBlob(blob, filename) {
+    let anchor = document.createElement('a');
+    document.body.appendChild(anchor);
+    anchor.style = 'display: none';
+
+    let url = window.URL.createObjectURL(blob);
+    anchor.href = url;
+    anchor.download = filename;
+    anchor.click();
+    window.URL.revokeObjectURL(url);
+}
+
+
 async function setImage(
-    filename, width, height, color, toAwaitBeforeLoad=null)
+    filename, width, height, pattern, color,
+    {toAwaitBeforeLoad = null, exifObj = null} = {})
 {
     let canvas = document.createElement('canvas');
     canvas.width = width;
     canvas.height = height;
     let context = canvas.getContext('2d');
     context.fillStyle = color;
-    context.fillRect(0, 0, canvas.width, canvas.height);
+
+    if (pattern === 'solid') {
+        // Fill entire image with this color.
+        context.fillRect(0, 0, canvas.width, canvas.height);
+    }
+    if (pattern === 'first_pixel') {
+        // Fill just the upper left pixel with this color.
+        // This can help to check that an image wasn't rotated
+        // unexpectedly.
+        context.fillRect(0, 0, 1, 1);
+    }
+    if (pattern === 'border') {
+        // Draw a thin outer border with this color.
+        // This can help to check that an image wasn't scaled down or up
+        // unexpectedly.
+        context.fillRect(0, 0, canvas.width, 1);
+        context.fillRect(0, 0, 1, canvas.height);
+        context.fillRect(0, canvas.height-1, canvas.width, 1);
+        context.fillRect(canvas.width-1, 0, 1, canvas.height);
+    }
 
     let imageContentType = 'image/jpeg';
     let blob = await new Promise(
         resolve => canvas.toBlob(resolve, imageContentType));
     let imageAsBinaryString =
         await AnnotationToolImageHelper.readBlob(blob);
+
+    if (exifObj) {
+        let exifStr = piexif.dump(exifObj);
+        imageAsBinaryString = piexif.insert(exifStr, imageAsBinaryString);
+    }
 
     let uint8Array = Uint8Array.from(
         imageAsBinaryString, c => c.charCodeAt(0));
@@ -103,7 +165,7 @@ QUnit.module("Load basic images", (hooks) => {
     });
 
     test("full image only", async function(assert) {
-        await setImage('full.jpg', FULL_WIDTH, FULL_HEIGHT, 'red');
+        await setImage('full.jpg', FULL_WIDTH, FULL_HEIGHT, 'solid', 'red');
         instantiateFullOnly();
         await imageHelper.loadSourceImages();
 
@@ -125,10 +187,11 @@ QUnit.module("Load basic images", (hooks) => {
         let {promise: checkedScaledImagePromise, resolve: csipResolve, reject}
             = Promise.withResolvers();
 
-        await setImage('scaled.jpg', SCALED_WIDTH, SCALED_HEIGHT, 'blue');
+        await setImage(
+            'scaled.jpg', SCALED_WIDTH, SCALED_HEIGHT, 'solid', 'blue');
         let {promise: fullImageAboutToLoadPromise} = await setImage(
-            'full.jpg', FULL_WIDTH, FULL_HEIGHT, 'red',
-            checkedScaledImagePromise,
+            'full.jpg', FULL_WIDTH, FULL_HEIGHT, 'solid', 'red',
+            {toAwaitBeforeLoad: checkedScaledImagePromise},
         );
         instantiate();
         let fullImageLoadedPromise = imageHelper.loadSourceImages();
@@ -154,5 +217,201 @@ QUnit.module("Load basic images", (hooks) => {
             red - green - blue > 200,
             "Should have loaded the full image, so an arbitrary pixel" +
             " should be close to red");
+    });
+});
+
+
+async function doExifRotationTest(assert, exifObj) {
+    await setImage(
+        'scaled.jpg', SCALED_WIDTH, SCALED_HEIGHT, 'first_pixel', 'blue');
+    await setImage(
+        'full.jpg', FULL_WIDTH, FULL_HEIGHT, 'first_pixel', 'red',
+        {exifObj: exifObj},
+    );
+
+    instantiate();
+    await imageHelper.loadSourceImages();
+
+    let pixelData = imageHelper.imageCanvas
+        .getContext('2d')
+        .getImageData(0, 0, 1, 1).data;
+    let [red, green, blue, _alpha] = pixelData;
+    assert.true(
+        red - green - blue > 200,
+        "Image should be loaded unrotated,"
+        + " so the upper left corner pixel should be close to red");
+}
+
+
+QUnit.module("EXIF rotation", (hooks) => {
+    hooks.beforeEach(async () => {
+        useFixture('main');
+    });
+    hooks.afterEach(() => {
+        fetchMock.reset();
+    });
+
+    test("No EXIF rotation", async function(assert) {
+        await doExifRotationTest(assert, {});
+    });
+
+    test("90 degree EXIF rotation in full image", async function(assert) {
+        let zeroth = {};
+        zeroth[piexif.ImageIFD.Orientation] = 6;
+        let exifObj = {'0th': zeroth};
+        await doExifRotationTest(assert, exifObj);
+    });
+});
+
+
+async function doExifScalingTest(assert, exifObj) {
+    await setImage(
+        'scaled.jpg', SCALED_WIDTH, SCALED_HEIGHT, 'border', 'blue');
+    await setImage(
+        'full.jpg', FULL_WIDTH, FULL_HEIGHT, 'border', 'red',
+        {exifObj: exifObj},
+    );
+
+    instantiate();
+    await imageHelper.loadSourceImages();
+
+    let pixelData = imageHelper.imageCanvas
+        .getContext('2d')
+        .getImageData(FULL_WIDTH-1, FULL_HEIGHT-1, 1, 1).data;
+    let [red, green, blue, _alpha] = pixelData;
+    assert.true(
+        red - green - blue > 200,
+        "Image should be loaded with full dimensions, faithful to the"
+        + " pixel data, so the far corner pixel should be close to red");
+}
+
+
+/*
+These test cases are based on Virtlink's comment here:
+https://github.com/coralnet/coralnet/issues/658#issuecomment-4268345016
+*/
+QUnit.module("EXIF scaling", (hooks) => {
+    hooks.beforeEach(async () => {
+        useFixture('main');
+    });
+    hooks.afterEach(() => {
+        fetchMock.reset();
+    });
+
+    test("No EXIF scaling fields present", async function(assert) {
+        await doExifScalingTest(assert, {});
+    });
+
+    /*
+    Lightroom Classic can produce images like this.
+    Not known to be a special case in any image viewers, but just making sure
+    our EXIF-related code doesn't do anything weird with it.
+    */
+    test("EXIF resolution fields present, but not dimension fields", async function(assert) {
+        let zeroth = {};
+        // Rational: array of numerator and denominator
+        zeroth[piexif.ImageIFD.XResolution] = [240, 1];
+        zeroth[piexif.ImageIFD.YResolution] = [240, 1];
+        zeroth[piexif.ImageIFD.ResolutionUnit] = 2;
+        let exifObj = {'0th': zeroth};
+
+        await doExifScalingTest(assert, exifObj);
+    });
+
+    /*
+    This test is for the following case in the HTML spec:
+    https://html.spec.whatwg.org/multipage/images.html#preparing-an-image-for-presentation
+    - dimX is a positive integer;
+    - dimY is a positive integer;
+    - resX is a positive floating-point number;
+    - resY is a positive floating-point number;
+    - physicalWidth × 72 / resX is dimX; [72 CSS points = 1 inch, per spec]
+    - physicalHeight × 72 / resY is dimY;
+    - resUnit is 2 (Inch)
+
+    PhotoPea can produce images like this. In this case, browsers use the
+    dimensions given in EXIF when displaying the image, per the spec.
+    However, it doesn't make sense for the annotation tool to respect these
+    EXIF dimensions: the canvas is already being scaled to the annotation
+    tool's interactable area.
+    So we make sure the annotation tool ignores these EXIF dimensions.
+
+    (For the record, this test's equivalent for centimeters instead
+    of inches did not get interpreted the same way by browsers. Not sure why
+    the spec only stipulates inches, but that's indeed how it is.)
+    */
+    test("EXIF resolution and dimension fields present, with dimensions * resolution / pixel data dimensions = 72", async function(assert) {
+        let zeroth = {};
+        // Rational: array of numerator and denominator
+        zeroth[piexif.ImageIFD.XResolution] = [240, 1];
+        zeroth[piexif.ImageIFD.YResolution] = [240, 1];
+        zeroth[piexif.ImageIFD.ResolutionUnit] = 2;
+        let exif = {};
+        exif[piexif.ExifIFD.PixelXDimension] = SCALED_WIDTH;
+        exif[piexif.ExifIFD.PixelYDimension] = SCALED_HEIGHT;
+        let exifObj = {'0th': zeroth, 'Exif': exif};
+
+        await doExifScalingTest(assert, exifObj);
+    });
+
+    /*
+    Images like this can come from Photoshop on Windows, or can come directly
+    from cameras.
+    Not known to be a special case in any image viewers, but just making sure
+    our EXIF-related code doesn't do anything weird with it.
+    */
+    test("EXIF resolution and dimension fields present, with dimensions = pixel data dimensions", async function(assert) {
+        let zeroth = {};
+        // Rational: array of numerator and denominator
+        zeroth[piexif.ImageIFD.XResolution] = [240, 1];
+        zeroth[piexif.ImageIFD.YResolution] = [240, 1];
+        zeroth[piexif.ImageIFD.ResolutionUnit] = 2;
+        let exif = {};
+        exif[piexif.ExifIFD.PixelXDimension] = FULL_WIDTH;
+        exif[piexif.ExifIFD.PixelYDimension] = FULL_HEIGHT;
+        let exifObj = {'0th': zeroth, 'Exif': exif};
+
+        await doExifScalingTest(assert, exifObj);
+    });
+});
+
+
+QUnit.module("EXIF error cases", (hooks) => {
+    hooks.beforeEach(async () => {
+        useFixture('main');
+    });
+    hooks.afterEach(() => {
+        fetchMock.reset();
+    });
+
+    test("Invalid file data", async function(assert) {
+    });
+
+    test("Unpack error", async function(assert) {
+    });
+
+    test("Incorrect value type to decode", async function(assert) {
+    });
+
+    test("Not jpeg", async function(assert) {
+    });
+
+    test("Error when setting up", async function(assert) {
+    });
+
+    test("Error when loading", async function(assert) {
+    });
+});
+
+
+QUnit.module("Other error cases", (hooks) => {
+    hooks.beforeEach(async () => {
+        useFixture('main');
+    });
+    hooks.afterEach(() => {
+        fetchMock.reset();
+    });
+
+    test("Error when retrieving image", async function(assert) {
     });
 });

--- a/project/annotations/static/js/tests/AnnotationToolImageQUnit.js
+++ b/project/annotations/static/js/tests/AnnotationToolImageQUnit.js
@@ -1,0 +1,158 @@
+const { test } = QUnit;
+import fetchMock from '/static/js/fetch-mock.js';
+
+import AnnotationToolImageHelper from '/static/js/AnnotationToolImageHelper.js';
+import { useFixture } from '/static/js/test-utils.js';
+
+let imageHelper;
+let SCALED_WIDTH = 800;
+let SCALED_HEIGHT = 600;
+let FULL_WIDTH = 3200;
+let FULL_HEIGHT = 2400;
+
+
+function instantiate() {
+    imageHelper = new AnnotationToolImageHelper(
+        {
+            'scaled': {
+                'url': 'scaled.jpg',
+                'width': SCALED_WIDTH,
+                'height': SCALED_HEIGHT,
+            },
+            'full': {
+                'url': 'full.jpg',
+                'width': FULL_WIDTH,
+                'height': FULL_HEIGHT,
+            },
+        },
+        null,
+        {},
+    );
+}
+
+
+function instantiateFullOnly() {
+    imageHelper = new AnnotationToolImageHelper(
+        {
+            'full': {
+                'url': 'full.jpg',
+                'width': FULL_WIDTH,
+                'height': FULL_HEIGHT,
+            },
+        },
+        null,
+        {},
+    );
+}
+
+
+async function setImage(
+    filename, width, height, color, toAwaitBeforeLoad=null)
+{
+    let canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    let context = canvas.getContext('2d');
+    context.fillStyle = color;
+    context.fillRect(0, 0, canvas.width, canvas.height);
+
+    let imageContentType = 'image/jpeg';
+    let blob = await new Promise(
+        resolve => canvas.toBlob(resolve, imageContentType));
+    let imageAsBinaryString =
+        await AnnotationToolImageHelper.readBlob(blob);
+
+    let uint8Array = Uint8Array.from(
+        imageAsBinaryString, c => c.charCodeAt(0));
+    blob = new Blob([uint8Array], {type: imageContentType});
+
+    if (toAwaitBeforeLoad) {
+        // A Promise has been given which allows the fetch-caller and
+        // the fetch-callback to wait for each other.
+        // 1. Caller waits for the callback's about-to-load resolution. Then
+        //    the caller can run some code, such as asserting expected state
+        //    at this point.
+        // 2. Callback waits for the caller's to-await-before-load resolution.
+        //    Then the callback here can proceed with loading the image.
+        let {promise: aboutToLoadPromise, resolve: atlResolve, reject}
+            = Promise.withResolvers();
+        let fetchCallback = async (url, options, request) => {
+            atlResolve();
+            await toAwaitBeforeLoad;
+            return new Response(blob);
+        };
+        fetchMock.get(filename, fetchCallback);
+        // We want to return the aboutToLoadPromise to the caller. To do so,
+        // we wrap the aboutToLoadPromise in a hash; because if we didn't
+        // wrap this Promise in anything, this Promise would become the
+        // Promise that's 'used up' by the `await setImage(...)` call.
+        return {'promise': aboutToLoadPromise};
+    }
+    else {
+        fetchMock.get(filename, new Response(blob));
+    }
+}
+
+
+QUnit.module("Load basic images", (hooks) => {
+    hooks.beforeEach(async () => {
+        useFixture('main');
+    });
+    hooks.afterEach(() => {
+        fetchMock.reset();
+    });
+
+    test("full image only", async function(assert) {
+        await setImage('full.jpg', FULL_WIDTH, FULL_HEIGHT, 'red');
+        instantiateFullOnly();
+        await imageHelper.loadSourceImages();
+
+        // Get any pixel (the first pixel, here).
+        let pixelData = imageHelper.imageCanvas
+            .getContext('2d').getImageData(0, 0, 1, 1).data;
+        let [red, green, blue, _alpha] = pixelData;
+
+        // This is jpg, so we don't expect a perfectly faithful
+        // (255,0,0) red.
+        // Instead just ensure this pixel is 'red enough'.
+        assert.true(
+            red - green - blue > 200,
+            "Should have loaded the image, so an arbitrary pixel should be" +
+            " close to red");
+    });
+
+    test("scaled image then full image", async function(assert) {
+        let {promise: checkedScaledImagePromise, resolve: csipResolve, reject}
+            = Promise.withResolvers();
+
+        await setImage('scaled.jpg', SCALED_WIDTH, SCALED_HEIGHT, 'blue');
+        let {promise: fullImageAboutToLoadPromise} = await setImage(
+            'full.jpg', FULL_WIDTH, FULL_HEIGHT, 'red',
+            checkedScaledImagePromise,
+        );
+        instantiate();
+        let fullImageLoadedPromise = imageHelper.loadSourceImages();
+
+        // Wait for loading to proceed far enough so that the scaled image
+        // is loaded, but the full image isn't yet.
+        await fullImageAboutToLoadPromise;
+        let pixelData = imageHelper.imageCanvas
+            .getContext('2d').getImageData(0, 0, 1, 1).data;
+        let [red, green, blue, _alpha] = pixelData;
+        assert.true(
+            blue - red - green > 200,
+            "Should have loaded the scaled image, so an arbitrary pixel" +
+            " should be close to blue");
+
+        // Allow loading of the full image to proceed.
+        csipResolve();
+        await fullImageLoadedPromise;
+        pixelData = imageHelper.imageCanvas
+            .getContext('2d').getImageData(0, 0, 1, 1).data;
+        [red, green, blue, _alpha] = pixelData;
+        assert.true(
+            red - green - blue > 200,
+            "Should have loaded the full image, so an arbitrary pixel" +
+            " should be close to red");
+    });
+});

--- a/project/annotations/static/js/tests/AnnotationToolImageQUnit.js
+++ b/project/annotations/static/js/tests/AnnotationToolImageQUnit.js
@@ -19,7 +19,12 @@ let originalPiexifLoad = piexif.load;
 let originalPiexifRemove = piexif.remove;
 
 
-function instantiate({scaled_name = 'scaled.jpg', full_name = 'full.jpg'} = {}) {
+function instantiate(
+        {
+            scaled_name = 'scaled.jpg', full_name = 'full.jpg',
+            full_width = FULL_WIDTH, full_height = FULL_HEIGHT,
+        } = {}) {
+
     imageHelper = new AnnotationToolImageHelper(
         {
             'scaled': {
@@ -29,8 +34,8 @@ function instantiate({scaled_name = 'scaled.jpg', full_name = 'full.jpg'} = {}) 
             },
             'full': {
                 'url': full_name,
-                'width': FULL_WIDTH,
-                'height': FULL_HEIGHT,
+                'width': full_width,
+                'height': full_height,
             },
         },
         null,
@@ -92,26 +97,44 @@ function makeCanvas(width, height, pattern, color) {
     canvas.width = width;
     canvas.height = height;
     let context = canvas.getContext('2d');
-    context.fillStyle = color;
 
     if (pattern === 'solid') {
         // Fill entire image with this color.
+        context.fillStyle = color;
         context.fillRect(0, 0, canvas.width, canvas.height);
     }
     if (pattern === 'first_pixel') {
         // Fill just the upper left pixel with this color.
         // This can help to check that an image wasn't rotated
         // unexpectedly.
+        context.fillStyle = color;
         context.fillRect(0, 0, 1, 1);
     }
     if (pattern === 'border') {
         // Draw a thin outer border with this color.
         // This can help to check that an image wasn't scaled down or up
         // unexpectedly.
+        context.fillStyle = color;
         context.fillRect(0, 0, canvas.width, 1);
         context.fillRect(0, 0, 1, canvas.height);
         context.fillRect(0, canvas.height-1, canvas.width, 1);
         context.fillRect(canvas.width-1, 0, 1, canvas.height);
+    }
+    if (pattern === 'checker') {
+        // Draw four quadrants of the image, each in a different color.
+        // Having multiple explicit colors allows contrast testing;
+        // two at an absolute minimum, but more makes the contrast changes
+        // truer to 'real' scenarios.
+        let [color1, color2, color3, color4] = color;
+        context.fillStyle = color1;
+        context.fillRect(0, 0, canvas.width/2, canvas.height/2);
+        context.fillStyle = color2;
+        context.fillRect(canvas.width/2, 0, canvas.width/2, canvas.height/2);
+        context.fillStyle = color3;
+        context.fillRect(
+            canvas.width/2, canvas.height/2, canvas.width/2, canvas.height/2);
+        context.fillStyle = color4;
+        context.fillRect(0, canvas.height/2, canvas.width/2, canvas.height/2);
     }
 
     return canvas;
@@ -231,6 +254,394 @@ QUnit.module("Load basic images", (hooks) => {
             red - green - blue > 200,
             "Should have loaded the full image, so an arbitrary pixel" +
             " should be close to red");
+    });
+});
+
+
+function setupBriConTest({perRectAction = null} = {}) {
+
+    let {promise: doneProcessingPromise, resolve: dppResolve, reject}
+        = Promise.withResolvers();
+    let originalApplyToRects =
+        imageHelper.applyBriConToRemainingRects.bind(imageHelper);
+    let newApply = (gain, bias, rects) => {
+        originalApplyToRects(gain, bias, rects);
+        if (perRectAction) {
+            // Some kind of bookkeeping, etc. for the test's purposes.
+            perRectAction();
+        }
+        // Resolve the Promise when the image is fully processed.
+        if (rects.length === 0) {
+            dppResolve();
+        }
+    };
+    imageHelper.applyBriConToRemainingRects = newApply.bind(imageHelper);
+    return doneProcessingPromise;
+}
+
+
+/* https://css-tricks.com/converting-color-spaces-in-javascript/ */
+function rgbToHsl(r, g, b) {
+    // Make r, g, and b fractions of 1
+    r /= 255;
+    g /= 255;
+    b /= 255;
+
+    // Find greatest and smallest channel values
+    let cmin = Math.min(r,g,b),
+        cmax = Math.max(r,g,b),
+        delta = cmax - cmin,
+        h,
+        s,
+        l;
+
+    // Calculate hue
+    // No difference
+    if (delta === 0)
+        h = 0;
+    // Red is max
+    else if (cmax === r)
+        h = ((g - b) / delta) % 6;
+    // Green is max
+    else if (cmax === g)
+        h = (b - r) / delta + 2;
+    // Blue is max
+    else
+        h = (r - g) / delta + 4;
+
+    h = Math.round(h * 60);
+
+    // Make negative hues positive behind 360°
+    if (h < 0)
+        h += 360;
+
+    // Calculate lightness
+    l = (cmax + cmin) / 2;
+
+    // Calculate saturation
+    s = delta === 0 ? 0 : delta / (1 - Math.abs(2 * l - 1));
+
+    // Multiply l and s by 100
+    s = +(s * 100).toFixed(1);
+    l = +(l * 100).toFixed(1);
+
+    return [h, s, l];
+}
+
+
+function assertCanvasColors(assert, expectedColors) {
+
+    // Pixels close to each of the four corners.
+    let context = imageHelper.imageCanvas.getContext('2d');
+    let pixelDatas = [
+        context.getImageData(10, 10, 1, 1).data,
+        context.getImageData(imageHelper.imageCanvas.width-10, 10, 1, 1).data,
+        context.getImageData(
+            imageHelper.imageCanvas.width-10,
+            imageHelper.imageCanvas.height-10, 1, 1).data,
+        context.getImageData(10, imageHelper.imageCanvas.height-10, 1, 1).data,
+    ];
+    let pixelNames = [
+        "Upper left", "Upper right", "Lower right", "Lower left"];
+    let index = 0;
+
+    for (let pixelData of pixelDatas) {
+        let [red, green, blue, _alpha] = pixelData;
+        let [hue, sat, light] = rgbToHsl(red, green, blue);
+        let [xhue, xsat, xlight] = expectedColors[index];
+
+        assert.true(
+            // We won't be exacting, due to the rgb -> hsl conversion
+            // and jpeg compression.
+            Math.abs(hue - xhue) < 4,
+            `${pixelNames[index]} pixel's hue should be close to expected`
+            + `(${hue} vs. ${xhue}`);
+        assert.true(
+            Math.abs(sat - xsat) < 4,
+            `${pixelNames[index]} pixel's saturation should be close to expected`
+            + `(${sat} vs. ${xsat}`);
+        assert.true(
+            Math.abs(light - xlight) < 4,
+            `${pixelNames[index]} pixel's lightness should be close to expected`
+            + `(${light} vs. ${xlight}`);
+
+        index++;
+    }
+}
+
+
+QUnit.module("Brightness and contrast", (hooks) => {
+    hooks.beforeEach(async () => {
+        useFixture('main');
+
+        await setImage(
+            'scaled.jpg', SCALED_WIDTH, SCALED_HEIGHT, 'solid', 'blue');
+        // Multicolor pattern, with nontrivial saturation and lightness, so
+        // that contrast and brightness adjustment do different nontrivial
+        // things.
+        await setImage(
+            'full.jpg', 2400, 1500, 'checker',
+            ['hsl(90 30% 70%)', 'hsl(140 70% 30%)',
+             'hsl(190 30% 30%)', 'hsl(240 70% 70%)'],
+        );
+        instantiate({full_width: 2400, full_height: 1500});
+
+        // Individual tests can overwrite this to increase/decrease the number
+        // of rectangles to process.
+        imageHelper.RECT_SIZE = 500;
+
+        imageHelper.brightnessSlider.value = 0;
+        imageHelper.brightnessField.value = 0;
+        imageHelper.contrastSlider.value = 0;
+        imageHelper.contrastField.value = 0;
+
+        await imageHelper.loadSourceImages();
+    });
+    hooks.afterEach(() => {
+        fetchMock.reset();
+    });
+
+    test.each(
+            "rect count",
+            [
+                [500, 5*3],
+                [480, 5*4],
+                [460, 6*4],
+            ],
+            async (assert, [rectSize, expectedRects]) => {
+
+        imageHelper.RECT_SIZE = rectSize;
+        let rectsProcessed = 0;
+        let perRectAction = () => {rectsProcessed++;}
+        let doneProcessingPromise =
+            setupBriConTest({perRectAction: perRectAction});
+
+        imageHelper.brightnessSlider.value = 20;
+        // Although redrawing happens on our change listener, we need to fire
+        // an input event first so that the updated slider value is recognized.
+        imageHelper.brightnessSlider.dispatchEvent(new Event('input'));
+        imageHelper.brightnessSlider.dispatchEvent(new Event('change'));
+        // Wait for the brightness application to finish on the whole image
+        await doneProcessingPromise;
+        assert.equal(
+            rectsProcessed, expectedRects,
+            "Number of rectangles processed for bri/con should be as" +
+            " expected, given the image width/height and rectangle size");
+    });
+
+    test("brightness slider", async function(assert) {
+        let doneProcessingPromise = setupBriConTest();
+
+        imageHelper.brightnessSlider.value = 20;
+        assert.equal(
+            imageHelper.brightnessField.value, 0,
+            "Field value should not have changed yet");
+        // Should not have redrawn with new brightness
+        assertCanvasColors(
+            assert, [[90,30,70], [140,70,30], [190,30,30], [240,70,70]]);
+
+        imageHelper.brightnessSlider.dispatchEvent(new Event('input'));
+        assert.equal(
+            imageHelper.brightnessField.value, 20,
+            "Field value should have changed");
+        // Should not have redrawn with new brightness
+        assertCanvasColors(
+            assert, [[90,30,70], [140,70,30], [190,30,30], [240,70,70]]);
+
+        imageHelper.brightnessSlider.dispatchEvent(new Event('change'));
+        // Wait for the brightness application to finish on the whole image
+        await doneProcessingPromise;
+        // Should have redrawn with new brightness
+        assertCanvasColors(
+            assert, [[90,49,82], [140,50,42], [190,22,42], [240,100,80]]);
+    });
+
+    test("contrast slider", async function(assert) {
+        let doneProcessingPromise = setupBriConTest();
+
+        imageHelper.contrastSlider.value = 20;
+        assert.equal(
+            imageHelper.contrastField.value, 0,
+            "Field value should not have changed yet");
+        // Should not have redrawn with new contrast
+        assertCanvasColors(
+            assert, [[90,30,70], [140,70,30], [190,30,30], [240,70,70]]);
+
+        imageHelper.contrastSlider.dispatchEvent(new Event('input'));
+        assert.equal(
+            imageHelper.contrastField.value, 20,
+            "Field value should have changed");
+        // Should not have redrawn with new contrast
+        assertCanvasColors(
+            assert, [[90,30,70], [140,70,30], [190,30,30], [240,70,70]]);
+
+        imageHelper.contrastSlider.dispatchEvent(new Event('change'));
+        // Wait for the contrast application to finish on the whole image
+        await doneProcessingPromise;
+        // Should have redrawn with new contrast
+        assertCanvasColors(
+            assert, [[66,100,93], [140,70,42], [190,30,42], [240,100,84]]);
+    });
+
+    test("negative brightness", async function(assert) {
+        let doneProcessingPromise = setupBriConTest();
+
+        imageHelper.brightnessSlider.value = -30;
+        imageHelper.brightnessSlider.dispatchEvent(new Event('input'));
+        imageHelper.brightnessSlider.dispatchEvent(new Event('change'));
+
+        assert.equal(
+            imageHelper.brightnessField.value, -30,
+            "Field value should have changed");
+
+        await doneProcessingPromise;
+        assertCanvasColors(
+            assert, [[89,19,52], [131,100,17], [190,74,12], [240,44,52]]);
+    });
+
+    test("negative contrast", async function(assert) {
+        let doneProcessingPromise = setupBriConTest();
+
+        imageHelper.contrastSlider.value = -30;
+        imageHelper.contrastSlider.dispatchEvent(new Event('input'));
+        imageHelper.contrastSlider.dispatchEvent(new Event('change'));
+
+        assert.equal(
+            imageHelper.contrastField.value, -30,
+            "Field value should have changed");
+
+        await doneProcessingPromise;
+        assertCanvasColors(
+            assert, [[88,15,54], [140,70,23], [190,30,23], [240,35,54]]);
+    });
+
+    test("brightness text field", async function(assert) {
+        let doneProcessingPromise = setupBriConTest();
+
+        imageHelper.brightnessField.value = 120;
+        imageHelper.brightnessField.dispatchEvent(new Event('change'));
+        assert.equal(
+            imageHelper.brightnessSlider.value, 0,
+            "Slider value should not have updated, due to out-of-range input");
+        // Should not have redrawn with new brightness
+        assertCanvasColors(
+            assert, [[90,30,70], [140,70,30], [190,30,30], [240,70,70]]);
+
+        imageHelper.brightnessField.value = 100;
+        imageHelper.brightnessField.dispatchEvent(new Event('change'));
+        assert.equal(
+            imageHelper.brightnessSlider.value, 100,
+            "Slider value should have updated");
+        // Wait for the brightness application to finish on the whole image
+        await doneProcessingPromise;
+        // Should have redrawn with new brightness
+        assertCanvasColors(
+            assert, [[0,0,100], [147,100,84], [190,79,89], [0,0,100]]);
+    });
+
+    test("contrast text field", async function(assert) {
+        let doneProcessingPromise = setupBriConTest();
+
+        imageHelper.contrastField.value = -120;
+        imageHelper.contrastField.dispatchEvent(new Event('change'));
+        assert.equal(
+            imageHelper.contrastSlider.value, 0,
+            "Slider value should not have updated, due to out-of-range input");
+        // Should not have redrawn with new contrast
+        assertCanvasColors(
+            assert, [[90,30,70], [140,70,30], [190,30,30], [240,70,70]]);
+
+        imageHelper.contrastField.value = -100;
+        imageHelper.contrastField.dispatchEvent(new Event('change'));
+        assert.equal(
+            imageHelper.contrastSlider.value, -100,
+            "Slider value should have updated");
+        // Wait for the contrast application to finish on the whole image
+        await doneProcessingPromise;
+        // Should have redrawn with new contrast
+        assertCanvasColors(
+            assert, [[87,12,18], [140,70,8], [190,30,8], [240,30,18]]);
+    });
+
+    test("reset button", async function(assert) {
+        let doneProcessingPromise = setupBriConTest();
+
+        imageHelper.brightnessSlider.value = 20;
+        imageHelper.brightnessSlider.dispatchEvent(new Event('input'));
+        imageHelper.brightnessSlider.dispatchEvent(new Event('change'));
+        await doneProcessingPromise;
+        // Should have redrawn with new brightness
+        assertCanvasColors(
+            assert, [[90,49,82], [140,50,42], [190,22,42], [240,100,80]]);
+
+        imageHelper.resetButton.dispatchEvent(new Event('click'));
+        // Should have reset; this should happen synchronously
+        assertCanvasColors(
+            assert, [[90,30,70], [140,70,30], [190,30,30], [240,70,70]]);
+    });
+
+    test("overlapping actions", async function(assert) {
+        // We expect 5*3 = 15 rectangles.
+        imageHelper.RECT_SIZE = 500;
+
+        let updatedContrast = false;
+        let {promise: updatedContrastPromise, resolve: ucpResolve, reject1}
+            = Promise.withResolvers();
+
+        let {promise: halfDoneBrightnessPromise, resolve: hdbpResolve, reject2}
+            = Promise.withResolvers();
+        let {promise: doneBriAndConPromise, resolve: dbacpResolve, reject3}
+            = Promise.withResolvers();
+        let originalApplyToRects =
+            imageHelper.applyBriConToRemainingRects.bind(imageHelper);
+        let applyCalls = 0;
+        let newApply = (gain, bias, rects) => {
+            if (!updatedContrast && rects.length === 7) {
+                // 7 rectangles left (8 processed) in the brightness-only phase.
+                hdbpResolve();
+                // Do not proceed until we update the contrast slider.
+                updatedContrastPromise.then(
+                    originalApplyToRects.bind(imageHelper, gain, bias, rects));
+            }
+            else {
+                originalApplyToRects(gain, bias, rects);
+
+                if (updatedContrast && rects.length === 0) {
+                    // 0 rectangles left (15 processed) in the
+                    // brightness-and-contrast phase.
+                    dbacpResolve();
+                }
+            }
+            applyCalls++;
+        };
+        imageHelper.applyBriConToRemainingRects = newApply.bind(imageHelper);
+
+        // Set brightness to 20 and trigger the events to start processing it.
+        imageHelper.brightnessSlider.value = 20;
+        imageHelper.brightnessSlider.dispatchEvent(new Event('input'));
+        imageHelper.brightnessSlider.dispatchEvent(new Event('change'));
+        // Wait for half the rectangles to be processed.
+        await halfDoneBrightnessPromise;
+
+        // At this point processing should be paused halfway (we forced it to
+        // wait for a Promise).
+        // Set contrast to 20 and trigger the events to start processing it.
+        imageHelper.contrastSlider.value = 20;
+        imageHelper.contrastSlider.dispatchEvent(new Event('input'));
+        imageHelper.contrastSlider.dispatchEvent(new Event('change'));
+        updatedContrast = true;
+        // Unpause processing. This should interrupt the previous half-done
+        // processing, and start a new round of processing.
+        ucpResolve();
+        // Wait for all the rectangles to be processed.
+        await doneBriAndConPromise;
+
+        assert.equal(
+            applyCalls, 8+1+15,
+            "24 apply calls should have been processed: 8 for processing" +
+            " rects in the brightness-only phase, 1 to exit that phase," +
+            " and 15 in the bri+con phase (of note, phase 1 should have run" +
+            " only partially, so it shouldn't be 15 or 30 calls)");
     });
 });
 

--- a/project/annotations/static/js/tests/AnnotationToolImageQUnit.js
+++ b/project/annotations/static/js/tests/AnnotationToolImageQUnit.js
@@ -14,17 +14,21 @@ let SCALED_HEIGHT = 775;
 let FULL_WIDTH = 2568;
 let FULL_HEIGHT = 2583;
 
+let originalWindowAlert = window.alert;
+let originalPiexifLoad = piexif.load;
+let originalPiexifRemove = piexif.remove;
 
-function instantiate() {
+
+function instantiate({scaled_name = 'scaled.jpg', full_name = 'full.jpg'} = {}) {
     imageHelper = new AnnotationToolImageHelper(
         {
             'scaled': {
-                'url': 'scaled.jpg',
+                'url': scaled_name,
                 'width': SCALED_WIDTH,
                 'height': SCALED_HEIGHT,
             },
             'full': {
-                'url': 'full.jpg',
+                'url': full_name,
                 'width': FULL_WIDTH,
                 'height': FULL_HEIGHT,
             },
@@ -83,10 +87,7 @@ function downloadBlob(blob, filename) {
 }
 
 
-async function setImage(
-    filename, width, height, pattern, color,
-    {toAwaitBeforeLoad = null, exifObj = null} = {})
-{
+function makeCanvas(width, height, pattern, color) {
     let canvas = document.createElement('canvas');
     canvas.width = width;
     canvas.height = height;
@@ -113,20 +114,33 @@ async function setImage(
         context.fillRect(canvas.width-1, 0, 1, canvas.height);
     }
 
-    let imageContentType = 'image/jpeg';
+    return canvas;
+}
+
+
+async function setImage(
+    filename, width, height, pattern, color,
+    {toAwaitBeforeLoad = null, exifObj = null,
+     imageContentType = 'image/jpeg'} = {})
+{
+    let canvas = makeCanvas(width, height, pattern, color);
+
     let blob = await new Promise(
         resolve => canvas.toBlob(resolve, imageContentType));
-    let imageAsBinaryString =
-        await AnnotationToolImageHelper.readBlob(blob);
 
     if (exifObj) {
+        // Convert to string for piexif
+        let imageAsBinaryString =
+            await AnnotationToolImageHelper.readBlob(blob);
+
         let exifStr = piexif.dump(exifObj);
         imageAsBinaryString = piexif.insert(exifStr, imageAsBinaryString);
-    }
 
-    let uint8Array = Uint8Array.from(
-        imageAsBinaryString, c => c.charCodeAt(0));
-    blob = new Blob([uint8Array], {type: imageContentType});
+        // Back to a blob
+        let uint8Array = Uint8Array.from(
+            imageAsBinaryString, c => c.charCodeAt(0));
+        blob = new Blob([uint8Array], {type: imageContentType});
+    }
 
     if (toAwaitBeforeLoad) {
         // A Promise has been given which allows the fetch-caller and
@@ -376,30 +390,220 @@ QUnit.module("EXIF scaling", (hooks) => {
 });
 
 
+async function makeImageWithExif(exifObj) {
+    let canvas = makeCanvas(FULL_WIDTH, FULL_HEIGHT, 'solid', 'red');
+    let blob = await new Promise(
+        resolve => canvas.toBlob(resolve, 'image/jpeg'));
+    let imageAsString =
+        await AnnotationToolImageHelper.readBlob(blob);
+    let editedExifStr = piexif.dump(exifObj);
+    return piexif.insert(editedExifStr, imageAsString);
+}
+
+
+async function makeImageWithResolutionExif() {
+    let zeroth = {};
+    zeroth[piexif.ImageIFD.XResolution] = [240, 1];
+    zeroth[piexif.ImageIFD.YResolution] = [240, 1];
+    zeroth[piexif.ImageIFD.ResolutionUnit] = 2;
+    let exifObj = {'0th': zeroth};
+
+    return makeImageWithExif(exifObj);
+}
+
+
+async function assertExifIntact(assert, imageAsString, message) {
+    let exifObj = piexif.load(imageAsString);
+    let zeroth = exifObj['0th']
+    assert.deepEqual(
+        // These are the resolution fields.
+        [zeroth['282'], zeroth['283'], zeroth['296']],
+        [[240, 1], [240, 1], 2],
+        message,
+    );
+}
+
+
 QUnit.module("EXIF error cases", (hooks) => {
     hooks.beforeEach(async () => {
         useFixture('main');
     });
     hooks.afterEach(() => {
         fetchMock.reset();
+        window.alert = originalWindowAlert;
+        piexif.load = originalPiexifLoad;
+        piexif.remove = originalPiexifRemove;
+    });
+
+    /*
+    This test ensures that the general pattern of the following tests,
+    excluding the mocking of piexif.load() to throw certain errors,
+    results in the EXIF remaining intact.
+    */
+    test("No error leaves EXIF intact", async function(assert) {
+        let imageWithExifAsString = await makeImageWithResolutionExif();
+
+        let processedImageAsString = AnnotationToolImageHelper
+            .resetImageExifOrientation(imageWithExifAsString);
+
+        await assertExifIntact(
+            assert, processedImageAsString,
+            "EXIF should be intact after loading into canvas");
+    });
+
+    /*
+    Ensure that this piexif error results in the EXIF being stripped
+    before further processing.
+
+    This test deals directly with the image binary data, because
+    testing at the canvas level instead does not preserve EXIF. That is,
+    while writing image data to a canvas takes the EXIF into account when
+    writing the pixels to the canvas, the canvas does not contain
+    EXIF data in it. So going back out from canvas to image binary data
+    cannot get any EXIF, which makes it impossible to test the specific
+    thing we want to test.
+    */
+    test("Unpack error", async function(assert) {
+        let imageWithExifAsString = await makeImageWithResolutionExif();
+
+        // Ideally we'd be able to construct some EXIF data which actually
+        // gets this error, but that seemingly requires either an externally
+        // constructed fixture or substantial duplication of low-level
+        // piexif logic.
+        // We'll just go simpler and fake it.
+
+        piexif.load = () => {
+            throw new Error("'unpack' error. Got invalid type argument.");
+        };
+        let processedImageAsString = AnnotationToolImageHelper
+            .resetImageExifOrientation(imageWithExifAsString);
+        piexif.load = originalPiexifLoad;
+
+        let processedImageExifObj = piexif.load(processedImageAsString);
+        assert.equal(
+            Object.keys(processedImageExifObj['0th']).length, 0,
+            "Entire EXIF should be stripped after detecting an invalid type",
+        );
     });
 
     test("Invalid file data", async function(assert) {
-    });
+        let imageWithExifAsString = await makeImageWithResolutionExif();
 
-    test("Unpack error", async function(assert) {
+        // Ideally we'd be able to construct an image with "EXIF" data which
+        // actually gets this error, but that seemingly requires either an
+        // externally constructed fixture or substantial duplication of
+        // low-level piexif logic.
+        // We'll just go simpler and fake it.
+
+        piexif.load = () => {
+            throw new Error("'load' gots invalid file data.");
+        };
+        let processedImageAsString = AnnotationToolImageHelper
+            .resetImageExifOrientation(imageWithExifAsString);
+        piexif.load = originalPiexifLoad;
+
+        let processedImageExifObj = piexif.load(processedImageAsString);
+        assert.equal(
+            Object.keys(processedImageExifObj['0th']).length, 0,
+            "Entire EXIF should be stripped after detecting invalid data",
+        );
     });
 
     test("Incorrect value type to decode", async function(assert) {
+        let imageWithExifAsString = await makeImageWithResolutionExif();
+
+        // Ideally we'd be able to construct some EXIF data which actually
+        // gets this error, but that seemingly requires either a fixture or
+        // substantial duplication of low-level piexif logic.
+        // We'll just go simpler and fake it.
+        piexif.load = () => {
+            throw new Error(
+                "Exif might be wrong. Got incorrect value type to decode." +
+                " type:0");
+        };
+        let processedImageAsString = AnnotationToolImageHelper
+            .resetImageExifOrientation(imageWithExifAsString);
+        piexif.load = originalPiexifLoad;
+
+        let processedImageExifObj = piexif.load(processedImageAsString);
+        assert.equal(
+            Object.keys(processedImageExifObj['0th']).length, 0,
+            "Entire EXIF should be stripped after detecting an incorrect" +
+            " value type",
+        );
     });
 
+    /*
+    A more meaningful version of this test would involve using a PNG that
+    actually has EXIF data. However, that would currently require an externally
+    constructed fixture, which we haven't bothered to make yet.
+    */
     test("Not jpeg", async function(assert) {
-    });
+        let canvas = makeCanvas(
+            FULL_WIDTH, FULL_HEIGHT, 'first_pixel', 'red',
+        );
 
-    test("Error when setting up", async function(assert) {
+        let blob = await new Promise(
+            resolve => canvas.toBlob(resolve, 'image/png'));
+        let originalImageString =
+            await AnnotationToolImageHelper.readBlob(blob);
+        let processedImageString = AnnotationToolImageHelper
+            .resetImageExifOrientation(originalImageString);
+        assert.strictEqual(
+            originalImageString, processedImageString,
+            "PNG should be unedited");
     });
 
     test("Error when loading", async function(assert) {
+        // Mock window.alert() so that we don't actually have to interact
+        // with an alert dialog. Also, so we can assert its contents.
+        let alertMessage;
+        window.alert = (message) => {alertMessage = message;};
+
+        try {
+            // It's expecting the image as a string, and we're giving
+            // a Number.
+            AnnotationToolImageHelper
+                .resetImageExifOrientation(10);
+        }
+        catch {
+            // We could get the thrown error's message here, but
+            // we're just asserting on the alert message which
+            // contains that already.
+        }
+
+        assert.strictEqual(
+            alertMessage,
+            `Error when loading the image: "'load' gots invalid`
+            + ` type argument."`
+            + ` \nIf the problem persists, please notify the admins.`);
+    });
+
+    test("Error when setting up", async function(assert) {
+        // This case shouldn't happen unless there's a possible situation we
+        // don't know about. But we want to ensure the user is alerted in
+        // this case.
+        // resetImageExifOrientation() has a piexif.load() call and a
+        // piexif.remove() call, both taking the same arg. To test this case,
+        // we want the arg to be invalid for only the second call.
+        // To fake this, we mock piexif.remove() to just throw an unexpected
+        // error.
+        piexif.remove = () => {throw new Error("Unexpected error");};
+
+        let alertMessage;
+        window.alert = (message) => {alertMessage = message;};
+
+        try {
+            // We get to the remove() call using the invalid file data case.
+            AnnotationToolImageHelper.resetImageExifOrientation('test');
+        }
+        catch {
+        }
+
+        assert.strictEqual(
+            alertMessage,
+            `Error when setting up the image: "Unexpected error"`
+            + ` \nIf the problem persists, please notify the admins.`);
     });
 });
 
@@ -410,8 +614,25 @@ QUnit.module("Other error cases", (hooks) => {
     });
     hooks.afterEach(() => {
         fetchMock.reset();
+        window.alert = originalWindowAlert;
     });
 
     test("Error when retrieving image", async function(assert) {
+        fetchMock.get('full.jpg', () => {throw new Error("An error");});
+        instantiateFullOnly();
+
+        let alertMessage;
+        window.alert = (message) => {alertMessage = message;};
+
+        try {
+            await imageHelper.loadSourceImages();
+        }
+        catch {
+        }
+
+        assert.strictEqual(
+            alertMessage,
+            `Error when retrieving the full image: "An error"`
+            + ` \nIf the problem persists, please notify the admins.`);
     });
 });

--- a/project/annotations/templates/annotations/annotation_image_options.html
+++ b/project/annotations/templates/annotations/annotation_image_options.html
@@ -1,19 +1,4 @@
-{% comment %}
-TODO: Make an abbreviated version of this with
-icons instead of "brightness" and "contrast".
-{% endcomment %}
-
-{% for field in image_options_form %}
-    {# Should only have the brightness and contrast fields here, for now... #}
-    <div class="field_wrapper">
-        <label for="{{ field.id_for_label }}" class="column_form_text_field">
-            {{ field.label }}:
-        </label>
-        {{ field }}
-        <br/>
-        <div id="{{ field.name }}_slider"></div>
-    </div>
-{% endfor %}
+{{ image_options_form }}
 
 <button id="resetImageOptionsButton" type="button">Reset</button>
 <span id="applyingText">Applying...</span>

--- a/project/annotations/templates/annotations/annotation_tool.html
+++ b/project/annotations/templates/annotations/annotation_tool.html
@@ -251,7 +251,11 @@
 
     // Initialize the Annotation Tool Image helper object.
     import AnnotationToolImageHelper from "{% static 'js/AnnotationToolImageHelper.js' %}";
-    let imageHelper = new AnnotationToolImageHelper({{ source_images|jsonify }});
+    let imageHelper = new AnnotationToolImageHelper(
+        {{ source_images|jsonify }},
+        "{% static 'img/placeholders/media-loading__150x150.png' %}",
+        {{ javascript_debugging|jsonify }}['AnnotationToolImageHelper'],
+    );
 
     // Initialize the Annotation Tool Helper object.
     AnnotationToolHelper.init({

--- a/project/annotations/templates/annotations/annotation_tool.html
+++ b/project/annotations/templates/annotations/annotation_tool.html
@@ -22,7 +22,6 @@
     {% include "static-local-include.html" with type="js" path="js/piexif.js" %}
 
     {% include "static-local-include.html" with type="js" path="js/AnnotationToolSettingsHelper.js" %}
-    {% include "static-local-include.html" with type="js" path="js/AnnotationToolImageHelper.js" %}
     {% include "static-local-include.html" with type="js" path="js/AnnotationToolAutocomplete.js" %}
     {% include "static-local-include.html" with type="js" path="js/AnnotationToolHelper.js" %}
 {% endblock %}
@@ -243,14 +242,17 @@
     
 
 <!-- Script in the body will run on page load. -->
-<script type="text/javascript">
+<script type="module">
     // Initialize the Annotation Tool Settings helper object.
     ATS.init({
         annotationToolSettingsSaveUrl:
             "{% url 'annotation_tool_settings_save' %}"
     });
+
     // Initialize the Annotation Tool Image helper object.
-    AnnotationToolImageHelper.init({{ source_images|jsonify }});
+    import AnnotationToolImageHelper from "{% static 'js/AnnotationToolImageHelper.js' %}";
+    let imageHelper = new AnnotationToolImageHelper({{ source_images|jsonify }});
+
     // Initialize the Annotation Tool Helper object.
     AnnotationToolHelper.init({
         fullHeight: {{ image.original_height }},
@@ -261,8 +263,11 @@
         labels: {{ labels|jsonify }},
         machineSuggestions: {{ label_scores|jsonify }},
         saveAnnotationsUrl: "{% url 'save_annotations_ajax' image.id %}",
-        isAnnotationAllDoneUrl: "{% url 'is_annotation_all_done_ajax' image.id %}"
+        isAnnotationAllDoneUrl: "{% url 'is_annotation_all_done_ajax' image.id %}",
+        imageHelper: imageHelper,
     });
+
+    await imageHelper.loadSourceImages();
 </script>
 
 {% endblock %}

--- a/project/annotations/templates/annotations/annotation_tool_image_qunit.html
+++ b/project/annotations/templates/annotations/annotation_tool_image_qunit.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+  <canvas id="imageCanvas"></canvas>
+
+  {% include "annotations/annotation_image_options.html" with image_options_form=image_options_form %}
+
+{% endblock %}

--- a/project/annotations/tests/js/views.py
+++ b/project/annotations/tests/js/views.py
@@ -1,0 +1,20 @@
+from lib.tests.utils_qunit import QUnitView
+from ...forms import AnnotationImageOptionsForm
+
+
+class AnnotationToolImageQUnitView(QUnitView):
+
+    test_template_name = 'annotations/annotation_tool_image_qunit.html'
+    javascript_functionality_modules = [
+        'js/piexif.js',
+    ]
+    javascript_test_modules = ['js/tests/AnnotationToolImageQUnit.js']
+
+    @property
+    def test_template_contexts(self):
+
+        return {
+            'main': {
+                'image_options_form': AnnotationImageOptionsForm(),
+            }
+        }

--- a/project/annotations/urls.py
+++ b/project/annotations/urls.py
@@ -1,10 +1,15 @@
 from django.urls import include, path
 from . import views
+from .tests.js import views as js_test_views
 
 general_urlpatterns = [
     path('tool_settings_save_ajax/',
          views.annotation_tool_settings_save,
          name="annotation_tool_settings_save"),
+
+    path('js_test_annotation_tool_image/',
+         js_test_views.AnnotationToolImageQUnitView.as_view(),
+         name="js_test_annotation_tool_image"),
 ]
 
 image_urlpatterns = [

--- a/project/config/settings.py
+++ b/project/config/settings.py
@@ -1388,6 +1388,14 @@ FORUM_LINK = 'https://groups.google.com/forum/#!forum/coralnet-users'
 #    dark theme kicks in.
 DARK_COLORS_AVAILABLE = env.bool('DARK_COLORS_AVAILABLE', default=False)
 
+# Debugging options for Javascript modules.
+# The idea is that a Javascript module called MyClass.js would have a key
+# ['MyClass'] in this hash, and the value under that key would be whatever
+# format that module wants.
+# Not including a particular key should result in no debug stuff being enabled
+# for that module.
+JAVASCRIPT_DEBUGGING = env.json('JAVASCRIPT_DEBUGGING', default={})
+
 # Media filepath patterns
 IMAGE_FILE_PATTERN = 'images/{name}{extension}'
 LABEL_THUMBNAIL_FILE_PATTERN = 'labels/{name}{extension}'

--- a/project/lib/context_processors.py
+++ b/project/lib/context_processors.py
@@ -6,4 +6,5 @@ def coralnet_settings(request):
         account_questions_link=settings.ACCOUNT_QUESTIONS_LINK,
         forum_link=settings.FORUM_LINK,
         dark_colors_available=settings.DARK_COLORS_AVAILABLE,
+        javascript_debugging=settings.JAVASCRIPT_DEBUGGING,
     )

--- a/project/lib/templates/lib/admin_tools.html
+++ b/project/lib/templates/lib/admin_tools.html
@@ -29,6 +29,7 @@
   <h2>QUnit test pages</h2>
   <ul class="detail_list">
     <li><a href="{% url 'js_test_util' %}">util.js</a></li>
+    <li><a href="{% url 'js_test_annotation_tool_image' %}">Annotation Tool - Image</a></li>
     <li><a href="{% url 'async_media:js_test_async_media' %}">Async Media</a></li>
     <li><a href="{% url 'js_test_browse_search_form' %}">Browse - Search form</a></li>
     <li><a href="{% url 'js_test_browse_images_actions' %}">Browse Images - Actions</a></li>

--- a/project/lib/templates/lib/forms/rows.html
+++ b/project/lib/templates/lib/forms/rows.html
@@ -15,9 +15,12 @@
       </div>
 
       <div>
-        <label for="{{ field.id_for_label }}">
-          {{ field.label }}:
-        </label>
+        {% if field.label %}
+          <label for="{{ field.id_for_label }}">
+            {{ field.label }}:
+          </label>
+        {% endif %}
+        {# Most fields should specify labels, but they can choose not to by specifying as "". In that case they should have a comparable accessibility feature such as a title attribute (which would be specified in field widget attrs): https://www.w3.org/WAI/WCAG22/Techniques/html/H65 #}
 
         {{ field }}
         {% include "lib/forms/field_help_text.html" with field=field %}


### PR DESCRIPTION
- Modernized Javascript style of `AnnotationToolImageHelper` and its usage:
  - Use a class, and import as a module
  - let instead of var
  - async/await instead of callbacks when doable
  - Replaced jQuery UI sliders (for brightness and contrast) with input type="range"
  - No longer need jQuery for anything else in this module either
- The brightness/contrast form now uses modern Django form rendering
- Added QUnit tests: covering image loading, EXIF scaling (based on issue #658 info), EXIF orientation, bri/con controls, and error cases
- Changed a couple of debugging snippets to now use Django settings, instead of being a 'uncomment this line and comment out that one' thing. The mechanism still feels a bit messy, so maybe it'll be revised again later

I've been wanting to start modernizing and unit-testing the Javascript code surrounding the annotation tool, so that the annotation tool's not as intimidating to work on. This feels like a good start. The main un-modernized part remaining in this module is the piexif dependency; piexifjs hasn't been updated since 2019. However, I haven't yet found a replacement for its ability to write EXIF data (not just read it) on the browser side.

Meanwhile, I also fixed the 'short-circuit if bri/con are 0' case. The fact that it was bugged meant that you'd see the text "Applying..." next to the bri/con controls when entering the annotation tool, even if you hadn't touched those controls yet. Now you should no longer see that. Also, since the browser won't do that unnecessary bri/con processing on 0/0 anymore, that's some browser CPU cycles saved every time you load the annotation tool.