### PR TITLE
Filter out macOS ._-prefixed files in CPC batch editor drag and drop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ coralnet_sqlite_database
 # Misc
 /misc_not_versioncontrolled/*
 /tmp/*
+.vscode/settings.json
+.vscode/launch.json

--- a/project/cpce/static/js/CPCBatchEditor.js
+++ b/project/cpce/static/js/CPCBatchEditor.js
@@ -256,6 +256,7 @@ class DataTransferReader {
     }
 
     isFileAccepted(file) {
+        if (file.name.startsWith('._')) return false;
         if (!this.acceptedExtensions) {
             // All extensions are accepted.
             return true;


### PR DESCRIPTION
macOS automatically creates hidden metadata files (e.g. ._IMG_0001.cpc) 
when dragging files from an external drive. These are not valid CPC files 
and can contain null bytes, causing server errors (similar to #134).

Fixed by rejecting files starting with ._ in DataTransferReader.isFileAccepted(), 
before any files are sent to the server.

Also add .vscode/ to .gitignore.

Fixes #619