### PR TITLE
Error handling for binary files in text-file uploads

### DIFF
--- a/project/cpce/tests/test_batch_editor.py
+++ b/project/cpce/tests/test_batch_editor.py
@@ -1,10 +1,12 @@
 from io import BytesIO
 import json
+from unittest import mock
 from zipfile import ZipFile
 
 from django.core.files.base import ContentFile
 from django.urls import reverse
 
+from lib.exceptions import FileProcessError
 from lib.tests.utils import BasePermissionTest, ClientTest
 
 
@@ -36,7 +38,7 @@ class PermissionTest(BasePermissionTest):
             deny_type=self.REQUIRE_LOGIN)
 
 
-class MainTest(ClientTest):
+class BaseCpcBatchEditTest(ClientTest):
 
     @classmethod
     def setUpTestData(cls):
@@ -67,17 +69,25 @@ class MainTest(ClientTest):
             + point_position_lines + point_label_lines + header_lines
         )
 
-    def batch_edit(self, post_data):
+    def process(self, post_data):
         self.client.force_login(self.user)
-        process_response = self.client.post(
+        return self.client.post(
             reverse('cpce:cpc_batch_editor_process_ajax'),
             post_data,
         )
+
+    def batch_edit(self, post_data):
+        process_response = self.process(post_data)
         timestamp = process_response.json()['session_data_timestamp']
+
+        self.client.force_login(self.user)
         return self.client.get(
             reverse('cpce:cpc_batch_editor_file_serve'),
             dict(session_data_timestamp=timestamp),
         )
+
+
+class MainTest(BaseCpcBatchEditTest):
 
     def test_ids_only(self):
         cpc_lines = self.make_cpc_lines(
@@ -221,3 +231,42 @@ class MainTest(ClientTest):
         self.assertTrue(
             cpc_content.startswith('"2"'),
             "Second CPC's filepath was mapped correctly")
+
+
+def raise_process_error(*_args):
+    raise FileProcessError("A process error")
+
+
+class ErrorCasesTest(BaseCpcBatchEditTest):
+
+    def test_cpc_file_process_error(self):
+
+        # Minimal valid inputs.
+        cpc_lines = self.make_cpc_lines(
+            point_count_line='1',
+            point_position_lines=['0,0']*1,
+            point_label_lines=['"1","A","Notes",""'],
+        )
+        cpc_content = ''.join([line + '\n' for line in cpc_lines])
+        cpc_file = ContentFile(cpc_content, name='1.cpc')
+
+        csv_lines = ['Old ID,New ID', 'A,B']
+        csv_content = ''.join([line + '\n' for line in csv_lines])
+        csv_file = ContentFile(csv_content, name='spec.csv')
+
+        post_data = dict(
+            cpc_files=[cpc_file],
+            cpc_filepaths=json.dumps({'1.cpc': '1.cpc'}),
+            label_spec_fields='id_only',
+            label_spec_csv=csv_file,
+        )
+
+        with mock.patch(
+            'cpce.views.text_file_to_unicode_stream',
+            raise_process_error,
+        ):
+            response = self.process(post_data)
+
+        self.assertDictEqual(
+            response.json(), dict(error="A process error"),
+            "Response JSON should be as expected")

--- a/project/cpce/views.py
+++ b/project/cpce/views.py
@@ -549,7 +549,12 @@ def cpc_batch_editor_process_ajax(request):
     )
     for cpc_file in cpc_files:
         # Read in a cpc file
-        cpc_stream = text_file_to_unicode_stream(cpc_file)
+        try:
+            cpc_stream = text_file_to_unicode_stream(cpc_file)
+        except FileProcessError as error:
+            return JsonResponse(dict(
+                error=str(error),
+            ))
         # Edit the cpc file
         filepath = filepath_lookup[cpc_file.name]
         cpc_strings[filepath] = cpc_edit_labels(

--- a/project/upload/tests/test_utils.py
+++ b/project/upload/tests/test_utils.py
@@ -1,5 +1,6 @@
 from io import BytesIO, StringIO
 
+from lib.exceptions import FileProcessError
 from lib.tests.utils import BaseTest
 from ..utils import csv_to_dicts, text_file_to_unicode_stream
 
@@ -94,3 +95,30 @@ class TextFileToUnicodeTest(BaseTest):
         )
         unicode_stream = text_file_to_unicode_stream(byte_stream)
         self.assertEqual(unicode_stream.read(), 'Trié\\1 Hélice')
+
+    def test_binary_file(self):
+        # Example start of an Excel (XLSX) file.
+        #
+        # Including only about 20% of this resulted in ISO-8859-1,
+        # and including about 50% resulted in MacCyrillic. So it does need
+        # to be about this long to make the encoding guesser give up.
+        byte_stream = BytesIO(
+            b'PK\x03\x04\x14\x00\x08\x08\x08\x00\xac\xbb\xec\\\x00\x00'
+            b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x1a\x00\x00\x00'
+            b'xl/_rels/workbook.xml.rels\xadRAj\xc30\x10\xbc\xe7\x15b'
+            b'\xef\xb5\xec\xa4\x84R,\xe7\x12\n\xb9\xa6\xe9\x03\x84\xbc\xb6'
+            b'LlIh7m\xf2\xfb\xaaMh\x1c\x08\xa1\x07\x9f\xc4\xccjg\x86a\xcb'
+            b'\xd5q\xe8\xc5\'F\xea\xbcSPd9\x08t\xc6\xd7\x9dk\x15|\xec\xde'
+            b'\x9e^`U\xcd\xca-\xf6\x9a\xd3\x17\xb2] \x91v\x1c)\xb0\xcc\xe1'
+            b'UJ2\x16\x07M\x99\x0f\xe8\xd2\xa4\xf1q\xd0\x9c`le\xd0f\xaf['
+            b'\x94\xf3<_\xca8\xd6\x80\xeaFSlj\x05qS\x17 v\xa7\x80\xff'
+            b'\xd1\xf6M\xd3\x19\\{s\x18\xd0\xf1\x1d\x0b\xc9i\x17\x93\xa0'
+            b'\x8e-\xb2\x82_x&\x8b,\x89\x81\xbc\x9fa>e\x06\xe2S\x8ft\rq\xc6'
+        )
+
+        with self.assertRaises(FileProcessError) as cm:
+            text_file_to_unicode_stream(byte_stream)
+        self.assertEqual(
+            str(cm.exception),
+            f"<file stream>: Failed to decode text file content."
+            " Could it be in a binary format like Excel (XLSX)?")

--- a/project/upload/utils.py
+++ b/project/upload/utils.py
@@ -53,11 +53,21 @@ def text_file_to_unicode_stream(text_file):
             except UnicodeDecodeError:
                 pass
 
-        # No known examples thus far result in total failure to decode content.
-        # But if we ever come across one, a reasonable action might be to go
+        # Binary files might reach this case.
+        #
+        # If we could distinguish between binary files vs. unknown text
+        # encodings, a reasonable action for the latter might be to go
         # with the first guess and not be strict about errors:
         # unicode_text = content.decode(encoding_guesses[0], errors='replace')
-        assert unicode_text is not None, "Failed to decode content"
+        # But we're not trying to make that distinction yet.
+        if unicode_text is None:
+            try:
+                name = text_file.name
+            except AttributeError:
+                name = "<file stream>"
+            raise FileProcessError(
+                f"{name}: Failed to decode text file content."
+                " Could it be in a binary format like Excel (XLSX)?")
 
     # Convert the text into a line-by-line stream.
     return StringIO(unicode_text, newline='')


### PR DESCRIPTION
This had the potential to result in internal server errors.

For the most part I just had to change one utility function to raise a FileProcessError instead of an AssertionError. Most of the views that use this function already catch FileProcessError. However, I also updated the CPC batch editor code to ensure it catches FileProcessError from here.