### PR TITLE
Make `test_has_own_classifiers()` consistent

### DIFF
--- a/project/sources/tests/test_source_main.py
+++ b/project/sources/tests/test_source_main.py
@@ -1,5 +1,4 @@
 import html
-import math
 import re
 from unittest import skip
 
@@ -279,13 +278,22 @@ class SourceMainBackendColumnTest(BaseTaskTest):
         classifier_1 = self.source.classifier_set.latest('pk')
         self.assertEqual(classifier_1.status, ClassifierStatuses.ACCEPTED.value)
 
-        # Train and reject a classifier. Override settings so that
+        # Ensure the accuracy's greater than zero.
+        classifier_1.accuracy = 0.60
+        classifier_1.save()
+
+        # Train and reject a classifier, so that the last saved is different
+        # from the last trained.
+        #
+        # To do so, override settings so that:
         # 1) we don't need more images to train a new classifier, and
         # 2) it's impossible to improve accuracy enough to accept
-        # another classifier.
+        # another classifier. So here, 60% times 2.0 would be 120%, and it's
+        # impossible to get over 100%.
         with override_settings(
-                NEW_CLASSIFIER_TRAIN_TH=0.0001,
-                NEW_CLASSIFIER_IMPROVEMENT_TH=math.inf):
+            NEW_CLASSIFIER_TRAIN_TH=0.0001,
+            NEW_CLASSIFIER_IMPROVEMENT_TH=2.0,
+        ):
             do_job(
                 'train_classifier', self.source.pk, source_id=self.source.pk)
             self.do_collect_spacer_jobs()


### PR DESCRIPTION
Previously the first classifier's accuracy could end up being 0%, which would make the second classifier get accepted even if the improvement threshold was infinity, leading to an assertion failure. Now we set the first classifier's accuracy ourselves to eliminate this possibility.

I'm not sure what are the chances of the failure, in terms of considering how training works, but if you look at the possible configurations: there'd be 1 validation set image, 5 points, and 3 possible labels for each. There are 3^5 = 243 possible ways to label those validation points. And given the ground-truth validation annotations, there'd be 2^5 = 32 possible sets of machine-annotations that get 0% accuracy on those points. So that gives some idea of the plausibility of 0%.

The test last failed in GitHub's CI this month, for this PR here: https://github.com/coralnet/coralnet/pull/669