### PR TITLE
Optimize batch delete+create of annotations+points

### DIFF
--- a/project/annotations/managers.py
+++ b/project/annotations/managers.py
@@ -39,31 +39,6 @@ class AnnotationQuerySet(QuerySet):
             " Or delete the Annotations one by one."
         )
 
-    def bulk_create(self, objs, *args, **kwargs):
-        """
-        Only use this for annotation creation cases where
-        django-reversion isn't needed, since this skips save() signals.
-        """
-        for obj in objs:
-            # confirmed field is generally expected to be set here instead of
-            # by the caller.
-            obj.confirmed = obj.user != get_robot_user()
-
-        new_annotations = super().bulk_create(objs, *args, **kwargs)
-
-        # Once saved, the objs have IDs. Set scrambled_sort_key using
-        # scrambled_sort_hash(), which uses the objs' IDs.
-        for anno in new_annotations:
-            anno.scrambled_sort_key = scrambled_sort_hash(anno)
-        self.bulk_update(new_annotations, ['scrambled_sort_key'])
-
-        images = Image.objects.filter(
-            annotation__in=new_annotations).distinct()
-        for image in images:
-            image.annoinfo.update_annotation_progress_fields()
-
-        return new_annotations
-
 
 class AnnotationManager(Manager):
 
@@ -192,3 +167,53 @@ class AnnotationManager(Manager):
             status=ImageAnnoStatuses.UNCONFIRMED.value
         ):
             annoinfo.update_annotation_progress_fields()
+
+    def bulk_create(self, objs, *args, **kwargs):
+        """
+        Similar idea to AnnotationQuerySet.delete().
+        """
+        raise TypeError(
+            "Use bulk_create_for_image() instead."
+            " Or create the Annotations one by one."
+        )
+
+    def bulk_create_for_image(self, objs, image: Image):
+        """
+        Only use this for annotation creation cases where
+        django-reversion isn't needed, since this skips save() signals.
+        """
+        for obj in objs:
+            # confirmed field is generally expected to be set here instead of
+            # by the caller.
+            obj.confirmed = obj.user != get_robot_user()
+
+            # image field can be set either by the caller or here. But it
+            # shouldn't be set to a different Image.
+            # We will, however, just trust that the Points referenced by
+            # the Annotations belong to this same image. Since checking
+            # Points adds a performance concern.
+            if obj.image_id is None:
+                obj.image = image
+            elif obj.image_id != image.pk:
+                raise ValueError(
+                    f"Args have clashing Images:"
+                    f" ID {obj.image_id} vs. ID {image.pk}")
+
+            # We do also check that the Source matches.
+            if obj.source_id != obj.image.source_id:
+                raise ValueError(
+                    f"Args have clashing Sources:"
+                    f" ID {obj.source_id} vs. ID {obj.image.source_id}")
+
+        new_annotations = Manager.bulk_create(self, objs)
+
+        # Once saved, the objs have IDs. Set scrambled_sort_key using
+        # scrambled_sort_hash(), which uses the objs' IDs.
+        for anno in new_annotations:
+            anno.scrambled_sort_key = scrambled_sort_hash(anno)
+        self.bulk_update(new_annotations, ['scrambled_sort_key'])
+
+        # Annotation progress info may need updating.
+        image.annoinfo.update_annotation_progress_fields()
+
+        return new_annotations

--- a/project/annotations/managers.py
+++ b/project/annotations/managers.py
@@ -1,15 +1,15 @@
 from enum import Enum
 from typing import Union
 
-from django.conf import settings
-from django.db import models
+from django.db.models import Manager, QuerySet
 
 from accounts.utils import get_robot_user
 from images.models import Image
-from .model_utils import scrambled_sort_hash
+from lib.utils import delete_queryset_in_chunks
+from .model_utils import ImageAnnoStatuses, scrambled_sort_hash
 
 
-class AnnotationQuerySet(models.QuerySet):
+class AnnotationQuerySet(QuerySet):
 
     def confirmed(self):
         """Confirmed annotations only."""
@@ -19,43 +19,25 @@ class AnnotationQuerySet(models.QuerySet):
         """Unconfirmed annotations only."""
         return self.filter(confirmed=False)
 
-    def delete_in_chunks(self):
-        """
-        Deletion would induce Django to fetch all Annotations to be deleted,
-        at the very least because there are SET_NULL FKs to Annotations. This
-        could run us out of memory in some cases with production amounts of
-        Annotations. This method allows deleting in chunks so that's not a
-        concern.
-        Pattern is from https://stackoverflow.com/questions/60736901/
-        We also use only() to reduce what's fetched.
-        """
-        queryset = self.only('pk')
-
-        while True:
-            chunk_pks = queryset[:settings.QUERYSET_CHUNK_SIZE].values('pk')
-            if chunk_pks:
-                self.model.objects.filter(pk__in=chunk_pks).only('pk').delete()
-            else:
-                break
-
     def delete(self):
         """
-        Batch-delete Annotations. Note that when this is used,
-        Annotation.delete() will not be called for each individual Annotation,
-        so we make sure to do the equivalent actions here.
+        When we delete Annotations, we want to update the relevant Images'
+        annotation-progress fields, while also being mindful of performance.
+        The way we ensure this is to make the Annotation deletion API more
+        specific, providing other functions like delete_for_image() and
+        delete_for_image_set(), while disabling this generic delete()
+        method so it can't be used by accident.
+
+        When we do really want to use a generic delete (should be rare), we
+        can still either delete the Annotations one by one, or we can do:
+        QuerySet.delete(my_annotation_queryset)
+        followed by some other code to update the ImageAnnotationInfo fields.
         """
-        # Get all the images corresponding to these annotations.
-        images = Image.objects.filter(annotation__in=self).distinct()
-        # Evaluate the queryset before deleting the annotations.
-        images = list(images)
-        # Delete the annotations.
-        return_values = super().delete()
-
-        # The images' annotation progress info may need updating.
-        for image in images:
-            image.annoinfo.update_annotation_progress_fields()
-
-        return return_values
+        raise TypeError(
+            "Use delete_for_image(), delete_for_image_set(),"
+            " or delete_unconfirmed_for_source() instead."
+            " Or delete the Annotations one by one."
+        )
 
     def bulk_create(self, objs, *args, **kwargs):
         """
@@ -83,7 +65,7 @@ class AnnotationQuerySet(models.QuerySet):
         return new_annotations
 
 
-class AnnotationManager(models.Manager):
+class AnnotationManager(Manager):
 
     # TODO: CoralNet 1.15 changed 'updated' to 'changed', and 'no change' to
     #  'not changed'. At some point, a data migration should be written to
@@ -184,3 +166,29 @@ class AnnotationManager(models.Manager):
 
         # Else, there's nothing to save, so don't do anything.
         return self.UpdateResultsCodes.NOT_CHANGED.value
+
+    def delete_for_image(self, image: Image):
+        QuerySet.delete(self.model.objects.filter(image=image))
+
+        # Annotation progress info may need updating.
+        image.annoinfo.update_annotation_progress_fields()
+
+    def delete_for_image_set(self, image_queryset: QuerySet):
+        images = list(image_queryset)
+
+        delete_queryset_in_chunks(
+            self.model.objects.filter(image__in=image_queryset))
+
+        # Annotation progress info may need updating.
+        for image in images:
+            image.annoinfo.update_annotation_progress_fields()
+
+    def delete_unconfirmed_for_source(self, source: 'Source'):
+        delete_queryset_in_chunks(
+            self.model.objects.filter(source=source, confirmed=False))
+
+        # Annotation progress info may need updating.
+        for annoinfo in source.imageannotationinfo_set.filter(
+            status=ImageAnnoStatuses.UNCONFIRMED.value
+        ):
+            annoinfo.update_annotation_progress_fields()

--- a/project/annotations/tests/test_delete.py
+++ b/project/annotations/tests/test_delete.py
@@ -6,7 +6,10 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.select import Select
 from selenium.webdriver.support.ui import WebDriverWait
-from django.test.utils import override_settings
+from django.db import connections
+from django.db.models import QuerySet
+from django.db.utils import DEFAULT_DB_ALIAS
+from django.test.utils import CaptureQueriesContext, override_settings
 from django.urls import reverse
 from django.utils import timezone
 
@@ -16,7 +19,6 @@ from sources.models import Source
 from vision_backend.tests.tasks.utils import TaskTestMixin
 from visualization.tests.utils import (
     BaseBrowseActionTest, BaseBrowseSeleniumTest, BrowseActionsFormTest)
-from ..managers import AnnotationQuerySet
 
 
 tz = timezone.get_current_timezone()
@@ -55,6 +57,9 @@ class BaseDeleteTest(BaseBrowseActionTest):
         self.assertFalse(
             image.annoinfo.confirmed,
             f"Image {image.metadata.name} should not be confirmed anymore")
+        self.assertIsNone(
+            image.annoinfo.last_annotation,
+            f"Image {image.metadata.name} should not have a last annotation")
 
     def assert_annotations_not_deleted(
         self, image, expected_count=2, expect_confirmed=True,
@@ -69,6 +74,9 @@ class BaseDeleteTest(BaseBrowseActionTest):
             self.assertTrue(
                 image.annoinfo.confirmed,
                 f"Image {image.metadata.name} should still be confirmed")
+        self.assertIsNotNone(
+            image.annoinfo.last_annotation,
+            f"Image {image.metadata.name} should have a last annotation")
 
     def assert_confirmation_message(self, count):
         """
@@ -287,14 +295,14 @@ class SuccessTest(BaseDeleteTest):
 
         # Delete for all images, while tracking how many chunks are used
         # when deleting.
-        annotation_delete = spy_decorator(AnnotationQuerySet.delete)
-        with mock.patch.object(AnnotationQuerySet, 'delete', annotation_delete):
+        queryset_delete = spy_decorator(QuerySet.delete)
+        with mock.patch.object(QuerySet, 'delete', queryset_delete):
             self.client.force_login(self.user)
             self.client.post(
                 self.url, self.default_search_params | dict(result_count=7))
 
         self.assertEqual(
-            annotation_delete.mock_obj.call_count, 4,
+            queryset_delete.mock_obj.call_count, 4,
             msg="Should require 4 chunks of 4 to delete 14 annotations"
         )
 
@@ -566,6 +574,54 @@ class ErrorTest(BaseDeleteTest):
 
         for image in self.images:
             self.assert_annotations_not_deleted(image)
+
+
+class QueriesTest(BaseDeleteTest):
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.img1, cls.img2, cls.img3, cls.img4, cls.img5 = cls.images
+
+        # Allow assertion messages to refer to the images by name.
+        cls.update_multiple_metadatas(
+            'name',
+            ['img1', 'img2', 'img3', 'img4', 'img5'],
+        )
+
+    def setUp(self):
+        super().setUp()
+
+        for image in self.images:
+            image.refresh_from_db()
+            self.add_annotations(self.user, image, {1: 'A', 2: 'B'})
+
+    def test_delete_all_query_complexity(self):
+        """
+        Delete annotations for all images in the source, and check that the
+        queries for doing so aren't too complex.
+        """
+        conn = connections[DEFAULT_DB_ALIAS]
+        self.client.force_login(self.user)
+        with CaptureQueriesContext(conn) as cm:
+            response = self.client.post(
+                self.url,
+                self.default_search_params | dict(result_count=5),
+            )
+        self.assertDictEqual(response.json(), dict(success=True))
+
+        # We had a really slow query here which had 3 levels of nested
+        # subqueries, making for 4 SELECTs in the query's SQL.
+        #
+        # Hopefully checking for the number of SELECTs like this doesn't
+        # pick up any queries that are actually OK.
+        for query in cm.captured_queries:
+            self.assertLess(
+                query['sql'].count('SELECT'), 4,
+                msg=f"Shouldn't have too many nested subqueries."
+                    f" Query is:\n{query['sql']}"
+            )
 
 
 # Make it easy to get multiple pages of results.

--- a/project/annotations/tests/test_models.py
+++ b/project/annotations/tests/test_models.py
@@ -150,14 +150,14 @@ class AnnoInfoUpdateTest(CnStandardTest):
         point.delete()
         self.assert_status_equal('confirmed')
 
-    def test_point_bulk_create(self):
+    def test_point_bulk_create_for_image(self):
         self.assert_status_equal('confirmed', msg="Sanity check")
 
         points = [
             Point(image=self.image, row=10, column=10, point_number=4),
             Point(image=self.image, row=20, column=20, point_number=5),
         ]
-        Point.objects.bulk_create(points)
+        Point.objects.bulk_create_for_image(points, self.image)
         self.assert_status_equal('unclassified')
 
     def test_point_delete_for_image(self):

--- a/project/annotations/tests/test_models.py
+++ b/project/annotations/tests/test_models.py
@@ -104,7 +104,7 @@ class ImageStatusLogicTest(CnStandardTest):
             unconfirmed=[], confirmed=[1, 2, 3])
 
     def test_has_no_points(self):
-        self.image.point_set.delete()
+        Point.objects.delete_for_image(self.image)
         self.do_test(
             'unclassified', 'not_started',
             unconfirmed=[], confirmed=[])
@@ -157,11 +157,15 @@ class AnnoInfoUpdateTest(CnStandardTest):
             Point(image=self.image, row=10, column=10, point_number=4),
             Point(image=self.image, row=20, column=20, point_number=5),
         ]
-        points = Point.objects.bulk_create(points)
+        Point.objects.bulk_create(points)
         self.assert_status_equal('unclassified')
 
-        Point.objects.filter(pk__in=[p.pk for p in points]).delete()
-        self.assert_status_equal('confirmed')
+    def test_point_delete_for_image(self):
+        self.assert_status_equal('confirmed', msg="Sanity check")
+
+        Point.objects.delete_for_image(self.image)
+        self.assertEqual(self.image.point_set.count(), 0, msg="Sanity check")
+        self.assert_status_equal('unclassified')
 
     def test_annotation_save(self):
         self.assert_status_equal('confirmed', msg="Sanity check")

--- a/project/annotations/tests/test_models.py
+++ b/project/annotations/tests/test_models.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 
 from accounts.utils import get_robot_user
-from images.models import Point
+from images.models import Image, Point
 from lib.tests.utils import CnMigrationTest, CnStandardTest
 from lib.tests.utils_data import sample_image_as_file
 from ..model_utils import (
@@ -49,8 +49,10 @@ class ImageStatusLogicTest(CnStandardTest):
             # all first, then delete the ones we don't want for the
             # purposes of the test.
             self.add_robot_annotations(self.classifier, self.image)
-            self.image.annotation_set.exclude(
-                point__point_number__in=unconfirmed).delete()
+            for annotation in self.image.annotation_set.exclude(
+                point__point_number__in=unconfirmed
+            ):
+                annotation.delete()
         if confirmed:
             self.add_annotations(
                 self.user, self.image,
@@ -125,87 +127,110 @@ class AnnoInfoUpdateTest(CnStandardTest):
 
         cls.image = cls.upload_image(cls.user, cls.source)
         cls.add_annotations(cls.user, cls.image)
+        cls.image2 = cls.upload_image(cls.user, cls.source)
+        cls.add_robot_annotations(cls.create_robot(cls.source), cls.image2)
 
-    def assertStatusEqual(self, expected_status, msg=None):
+    def assert_status_equal(self, expected_status, msg=None):
         self.image.annoinfo.refresh_from_db()
         self.assertEqual(
             self.image.annoinfo.status, expected_status, msg=msg)
 
+    def assert_image2_status_equal(self, expected_status, msg=None):
+        self.image2.annoinfo.refresh_from_db()
+        self.assertEqual(
+            self.image2.annoinfo.status, expected_status, msg=msg)
+
     def test_point_save_delete(self):
-        self.assertStatusEqual('confirmed', msg="Sanity check")
+        self.assert_status_equal('confirmed', msg="Sanity check")
 
         point = Point(image=self.image, row=10, column=10, point_number=4)
         point.save()
-        self.assertStatusEqual('unclassified')
+        self.assert_status_equal('unclassified')
 
         point.delete()
-        self.assertStatusEqual('confirmed')
+        self.assert_status_equal('confirmed')
 
     def test_point_bulk_create_delete(self):
-        self.assertStatusEqual('confirmed', msg="Sanity check")
+        self.assert_status_equal('confirmed', msg="Sanity check")
 
         points = [
             Point(image=self.image, row=10, column=10, point_number=4),
             Point(image=self.image, row=20, column=20, point_number=5),
         ]
         points = Point.objects.bulk_create(points)
-        self.assertStatusEqual('unclassified')
+        self.assert_status_equal('unclassified')
 
         Point.objects.filter(pk__in=[p.pk for p in points]).delete()
-        self.assertStatusEqual('confirmed')
+        self.assert_status_equal('confirmed')
 
     def test_annotation_save(self):
-        self.assertStatusEqual('confirmed', msg="Sanity check")
+        self.assert_status_equal('confirmed', msg="Sanity check")
 
         annotation = Annotation.objects.get(
             image=self.image, point__point_number=1)
         annotation.user = get_robot_user()
         annotation.save()
-        self.assertStatusEqual('unconfirmed')
+        self.assert_status_equal('unconfirmed')
 
     def test_annotation_delete(self):
-        self.assertStatusEqual('confirmed', msg="Sanity check")
+        self.assert_status_equal('confirmed', msg="Sanity check")
 
         annotation = Annotation.objects.get(
             image=self.image, point__point_number=1)
         annotation.delete()
-        self.assertStatusEqual('unclassified')
+        self.assert_status_equal('unclassified')
 
-    def test_annotation_bulk_delete(self):
-        self.assertStatusEqual('confirmed', msg="Sanity check")
+    def test_annotations_delete_for_image(self):
+        self.assert_status_equal('confirmed', msg="Sanity check")
 
-        self.image.annotation_set.delete()
-        self.assertStatusEqual('unclassified')
+        Annotation.objects.delete_for_image(self.image)
+        self.assert_status_equal('unclassified')
 
-        # Whenever django-reversion is replaced and bulk creation of
-        # Annotations is viable again, the below code can be used to test
-        # bulk creation.
+    def test_annotations_delete_for_image_set(self):
+        self.assert_status_equal('confirmed', msg="Sanity check")
+        self.assert_image2_status_equal('unconfirmed', msg="Sanity check")
 
-        # annotations = [
-        #     Annotation(
-        #         source=self.image.source,
-        #         image=self.image,
-        #         point=self.image.point_set.get(point_number=1),
-        #         label=self.labels.get(name='A'),
-        #         user=get_robot_user(),
-        #     ),
-        #     Annotation(
-        #         source=self.image.source,
-        #         image=self.image,
-        #         point=self.image.point_set.get(point_number=2),
-        #         label=self.labels.get(name='A'),
-        #         user=get_robot_user(),
-        #     ),
-        #     Annotation(
-        #         source=self.image.source,
-        #         image=self.image,
-        #         point=self.image.point_set.get(point_number=3),
-        #         label=self.labels.get(name='A'),
-        #         user=get_robot_user(),
-        #     ),
-        # ]
-        # Annotation.objects.bulk_create(annotations)
-        # self.assertStatusEqual('unconfirmed')
+        Annotation.objects.delete_for_image_set(Image.objects.all())
+        self.assert_status_equal('unclassified')
+        self.assert_image2_status_equal('unclassified')
+
+    def test_annotations_delete_unconfirmed_for_source(self):
+        self.assert_status_equal('confirmed', msg="Sanity check")
+        self.assert_image2_status_equal('unconfirmed', msg="Sanity check")
+
+        Annotation.objects.delete_unconfirmed_for_source(self.source)
+        self.assert_status_equal('confirmed')
+        self.assert_image2_status_equal('unclassified')
+
+    # Whenever django-reversion is replaced and bulk creation of
+    # Annotations is viable again, the below code can be used to test
+    # bulk creation.
+
+    # annotations = [
+    #     Annotation(
+    #         source=self.image.source,
+    #         image=self.image,
+    #         point=self.image.point_set.get(point_number=1),
+    #         label=self.labels.get(name='A'),
+    #         user=get_robot_user(),
+    #     ),
+    #     Annotation(
+    #         source=self.image.source,
+    #         image=self.image,
+    #         point=self.image.point_set.get(point_number=2),
+    #         label=self.labels.get(name='A'),
+    #         user=get_robot_user(),
+    #     ),
+    #     Annotation(
+    #         source=self.image.source,
+    #         image=self.image,
+    #         point=self.image.point_set.get(point_number=3),
+    #         label=self.labels.get(name='A'),
+    #         user=get_robot_user(),
+    #     ),
+    # ]
+    # Annotation.objects.bulk_create(annotations)
+    # self.assertStatusEqual('unconfirmed')
 
 
 class ScrambledSortKeyTest(CnStandardTest):

--- a/project/annotations/tests/test_models.py
+++ b/project/annotations/tests/test_models.py
@@ -150,7 +150,7 @@ class AnnoInfoUpdateTest(CnStandardTest):
         point.delete()
         self.assert_status_equal('confirmed')
 
-    def test_point_bulk_create_delete(self):
+    def test_point_bulk_create(self):
         self.assert_status_equal('confirmed', msg="Sanity check")
 
         points = [
@@ -206,35 +206,161 @@ class AnnoInfoUpdateTest(CnStandardTest):
         self.assert_status_equal('confirmed')
         self.assert_image2_status_equal('unclassified')
 
-    # Whenever django-reversion is replaced and bulk creation of
-    # Annotations is viable again, the below code can be used to test
-    # bulk creation.
+    def test_annotation_bulk_create_for_image(self):
+        self.assert_status_equal('confirmed', msg="Sanity check")
 
-    # annotations = [
-    #     Annotation(
-    #         source=self.image.source,
-    #         image=self.image,
-    #         point=self.image.point_set.get(point_number=1),
-    #         label=self.labels.get(name='A'),
-    #         user=get_robot_user(),
-    #     ),
-    #     Annotation(
-    #         source=self.image.source,
-    #         image=self.image,
-    #         point=self.image.point_set.get(point_number=2),
-    #         label=self.labels.get(name='A'),
-    #         user=get_robot_user(),
-    #     ),
-    #     Annotation(
-    #         source=self.image.source,
-    #         image=self.image,
-    #         point=self.image.point_set.get(point_number=3),
-    #         label=self.labels.get(name='A'),
-    #         user=get_robot_user(),
-    #     ),
-    # ]
-    # Annotation.objects.bulk_create(annotations)
-    # self.assertStatusEqual('unconfirmed')
+        Annotation.objects.delete_for_image(self.image)
+        self.assert_status_equal('unclassified', msg="Sanity check")
+
+        annotations = [
+            Annotation(
+                point=self.image.point_set.get(point_number=point_number),
+                label=self.labels.get(name='A'),
+                user=self.user,
+                source=self.image.source,
+            )
+            for point_number in [1,2,3]
+        ]
+        Annotation.objects.bulk_create_for_image(annotations, self.image)
+        self.assert_status_equal('confirmed')
+
+
+class AnnotationCreateTest(CnStandardTest):
+    """
+    Aspects of Annotation creation methods other than annoinfo fields.
+    """
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.user = cls.create_user()
+        cls.source = cls.create_source(
+            cls.user,
+            default_point_generation_method=dict(type='simple', points=3),
+        )
+
+        cls.labels = cls.create_labels(cls.user, ['A', 'B'], 'GroupA')
+        cls.create_labelset(cls.user, cls.source, cls.labels)
+
+        cls.image = cls.upload_image(cls.user, cls.source)
+
+    def test_image_fks_present(self):
+        annotations = [
+            Annotation(
+                point=self.image.point_set.get(point_number=point_number),
+                label=self.labels.get(name='A'),
+                user=self.user,
+                image=self.image,
+                source=self.source,
+            )
+            for point_number in [1,2,3]
+        ]
+        Annotation.objects.bulk_create_for_image(annotations, self.image)
+
+        self.assertEqual(self.image.annotation_set.count(), 3)
+
+    def test_image_fks_present_but_mismatched(self):
+        image2 = self.upload_image(self.user, self.source)
+
+        annotations = [
+            Annotation(
+                point=image2.point_set.get(point_number=point_number),
+                label=self.labels.get(name='A'),
+                user=self.user,
+                image=image2,
+                source=self.source,
+            )
+            for point_number in [1,2,3]
+        ]
+        with self.assertRaises(ValueError) as cm:
+            Annotation.objects.bulk_create_for_image(annotations, self.image)
+
+        self.assertEqual(
+            str(cm.exception),
+            f"Args have clashing Images:"
+            f" ID {image2.pk} vs. ID {self.image.pk}")
+
+        self.assertEqual(self.image.annotation_set.count(), 0)
+
+    def test_image_fks_present_but_source_mismatched(self):
+        source2 = self.create_source(self.user)
+
+        annotations = [
+            Annotation(
+                point=self.image.point_set.get(point_number=point_number),
+                label=self.labels.get(name='A'),
+                user=self.user,
+                image=self.image,
+                source=source2,
+            )
+            for point_number in [1,2,3]
+        ]
+        with self.assertRaises(ValueError) as cm:
+            Annotation.objects.bulk_create_for_image(annotations, self.image)
+
+        self.assertEqual(
+            str(cm.exception),
+            f"Args have clashing Sources:"
+            f" ID {source2.pk} vs. ID {self.source.pk}")
+
+        self.assertEqual(self.image.annotation_set.count(), 0)
+
+    def test_image_fks_absent(self):
+        annotations = [
+            Annotation(
+                point=self.image.point_set.get(point_number=point_number),
+                label=self.labels.get(name='A'),
+                user=self.user,
+                source=self.source,
+            )
+            for point_number in [1,2,3]
+        ]
+        Annotation.objects.bulk_create_for_image(annotations, self.image)
+
+        self.assertEqual(self.image.annotation_set.count(), 3)
+
+    def test_image_fks_absent_but_source_mismatched(self):
+        source2 = self.create_source(self.user)
+
+        annotations = [
+            Annotation(
+                point=self.image.point_set.get(point_number=point_number),
+                label=self.labels.get(name='A'),
+                user=self.user,
+                source=source2,
+            )
+            for point_number in [1,2,3]
+        ]
+        with self.assertRaises(ValueError) as cm:
+            Annotation.objects.bulk_create_for_image(annotations, self.image)
+
+        self.assertEqual(
+            str(cm.exception),
+            f"Args have clashing Sources:"
+            f" ID {source2.pk} vs. ID {self.source.pk}")
+
+        self.assertEqual(self.image.annotation_set.count(), 0)
+
+    def test_bulk_create_error(self):
+        annotations = [
+            Annotation(
+                point=self.image.point_set.get(point_number=point_number),
+                label=self.labels.get(name='A'),
+                user=self.user,
+                image=self.image,
+                source=self.source,
+            )
+            for point_number in [1,2,3]
+        ]
+        with self.assertRaises(TypeError) as cm:
+            Annotation.objects.bulk_create(annotations)
+
+        self.assertEqual(
+            str(cm.exception),
+            "Use bulk_create_for_image() instead."
+            " Or create the Annotations one by one.")
+
+        self.assertEqual(self.image.annotation_set.count(), 0)
 
 
 class ScrambledSortKeyTest(CnStandardTest):

--- a/project/annotations/tests/utils.py
+++ b/project/annotations/tests/utils.py
@@ -462,10 +462,13 @@ class UploadAnnotationsGeneralCasesTest(
 
         self.img1.annoinfo.refresh_from_db()
         self.assertIsNotNone(self.img1.annoinfo.last_annotation)
+        self.assertTrue(self.img1.annoinfo.confirmed)
         self.img2.annoinfo.refresh_from_db()
         self.assertIsNone(self.img2.annoinfo.last_annotation)
+        self.assertFalse(self.img2.annoinfo.confirmed)
         self.img3.annoinfo.refresh_from_db()
         self.assertIsNotNone(self.img3.annoinfo.last_annotation)
+        self.assertTrue(self.img3.annoinfo.confirmed)
 
     def check_label_codes_different_case(
             self, preview_response, upload_response):

--- a/project/annotations/utils.py
+++ b/project/annotations/utils.py
@@ -325,7 +325,7 @@ def import_annotations(image, event_creator_id, annotation_dicts):
             point_number=num, image=image)
         new_points.append(point)
     # Save to DB with an efficient bulk operation.
-    Point.objects.bulk_create(new_points)
+    Point.objects.bulk_create_for_image(new_points, image)
 
     # Mapping of newly-saved points.
     point_numbers_to_ids = dict(

--- a/project/annotations/utils.py
+++ b/project/annotations/utils.py
@@ -347,7 +347,7 @@ def import_annotations(image, event_creator_id, annotation_dicts):
     # Bulk-create bypasses the django-reversion signals,
     # which is what we want in this case (trying to obsolete
     # reversion for annotations).
-    Annotation.objects.bulk_create(new_annotations)
+    Annotation.objects.bulk_create_for_image(new_annotations, image)
 
     # Instead of a django-reversion revision, we'll create our
     # own Event.

--- a/project/annotations/views.py
+++ b/project/annotations/views.py
@@ -204,7 +204,7 @@ def batch_delete_annotations_ajax(request, source_id):
         return JsonResponse(dict(error=e.message))
 
     # Delete annotations.
-    Annotation.objects.filter(image__in=image_set).delete_in_chunks()
+    Annotation.objects.delete_for_image_set(image_set)
 
     # This should appear on the next browse load.
     messages.success(
@@ -725,9 +725,7 @@ class AnnotationsUploadConfirmView(View):
             image = Image.objects.get(pk=image_id, source=source)
 
             # Delete previous annotations and points for this image.
-            # Calling delete() on these querysets is more efficient
-            # than calling delete() on each of the individual objects.
-            Annotation.objects.filter(image=image).delete()
+            Annotation.objects.delete_for_image(image)
             Point.objects.filter(image=image).delete()
 
             # Create new points and annotations.

--- a/project/annotations/views.py
+++ b/project/annotations/views.py
@@ -726,7 +726,7 @@ class AnnotationsUploadConfirmView(View):
 
             # Delete previous annotations and points for this image.
             Annotation.objects.delete_for_image(image)
-            Point.objects.filter(image=image).delete()
+            Point.objects.delete_for_image(image)
 
             # Create new points and annotations.
             import_annotations(

--- a/project/cpce/tests/test_upload_general_cases.py
+++ b/project/cpce/tests/test_upload_general_cases.py
@@ -1,5 +1,5 @@
 # These tests should be one-to-one with
-# annotations/tests/test_annotations_general_cases.py.
+# annotations/tests/test_upload_general_cases.py.
 
 import codecs
 from unittest import mock
@@ -768,8 +768,8 @@ class QueriesPerImageTest(
         # Number of queries should be linear in image count, but with
         # not TOO large of a constant factor.
         # TODO: Improve this. At this time of writing, it can't get under
-        #  40 queries per image.
-        with self.assert_queries_less_than(20*50):
+        #  50 queries per image.
+        with self.assert_queries_less_than(20*60):
             self.preview_annotations(
                 self.user, self.source, cpc_files)
             self.upload_annotations(self.user, self.source)

--- a/project/images/managers.py
+++ b/project/images/managers.py
@@ -1,9 +1,9 @@
-from django.db import models
+from django.db.models import Manager, QuerySet
 
 from annotations.model_utils import ImageAnnoStatuses
 
 
-class ImageQuerySet(models.QuerySet):
+class ImageQuerySet(QuerySet):
 
     def confirmed(self):
         """Confirmed annotation status only."""
@@ -38,23 +38,26 @@ class ImageQuerySet(models.QuerySet):
         return self.filter(features__extracted=False, unprocessable_reason="")
 
 
-class PointQuerySet(models.QuerySet):
+class PointQuerySet(QuerySet):
 
     def delete(self):
-        """Batch-delete Points."""
-        from .models import Image
+        """
+        When we delete Points, we want to update the relevant Images'
+        annotation-progress fields, while also being mindful of performance.
+        The way we ensure this is to make the Annotation deletion API more
+        specific, providing other functions like delete_for_image(),
+        while disabling this generic delete() method so it can't
+        be used by accident.
 
-        # Get all the images corresponding to these points.
-        images = Image.objects.filter(point__in=self).distinct()
-        # Evaluate the queryset before deleting the points.
-        images = list(images)
-        # Delete the points.
-        return_values = super().delete()
-
-        for image in images:
-            image.annoinfo.update_annotation_progress_fields()
-
-        return return_values
+        When we do really want to use a generic delete (should be rare), we
+        can still either delete the Points one by one, or we can do:
+        QuerySet.delete(my_point_queryset)
+        followed by some other code to update the ImageAnnotationInfo fields.
+        """
+        raise TypeError(
+            "Use delete_for_image() instead."
+            " Or delete the Points one by one."
+        )
 
     def bulk_create(self, *args, **kwargs):
         from .models import Image
@@ -66,3 +69,12 @@ class PointQuerySet(models.QuerySet):
             image.annoinfo.update_annotation_progress_fields()
 
         return new_points
+
+
+class PointManager(Manager):
+
+    def delete_for_image(self, image: 'Image'):
+        QuerySet.delete(self.model.objects.filter(image=image))
+
+        # Annotation progress info may need updating.
+        image.annoinfo.update_annotation_progress_fields()

--- a/project/images/managers.py
+++ b/project/images/managers.py
@@ -59,17 +59,6 @@ class PointQuerySet(QuerySet):
             " Or delete the Points one by one."
         )
 
-    def bulk_create(self, *args, **kwargs):
-        from .models import Image
-
-        new_points = super().bulk_create(*args, **kwargs)
-
-        images = Image.objects.filter(point__in=new_points).distinct()
-        for image in images:
-            image.annoinfo.update_annotation_progress_fields()
-
-        return new_points
-
 
 class PointManager(Manager):
 
@@ -78,3 +67,30 @@ class PointManager(Manager):
 
         # Annotation progress info may need updating.
         image.annoinfo.update_annotation_progress_fields()
+
+    def bulk_create(self, objs, *args, **kwargs):
+        """
+        Similar idea to PointQuerySet.delete().
+        """
+        raise TypeError(
+            "Use bulk_create_for_image() instead."
+            " Or create the Points one by one."
+        )
+
+    def bulk_create_for_image(self, objs, image: 'Image'):
+        for obj in objs:
+            # image field can be set either by the caller or here. But it
+            # shouldn't be set to a different Image.
+            if obj.image_id is None:
+                obj.image = image
+            elif obj.image_id != image.pk:
+                raise ValueError(
+                    f"Args have clashing Images:"
+                    f" ID {obj.image_id} vs. ID {image.pk}")
+
+        new_points = Manager.bulk_create(self, objs)
+
+        # Annotation progress info may need updating.
+        image.annoinfo.update_annotation_progress_fields()
+
+        return new_points

--- a/project/images/models.py
+++ b/project/images/models.py
@@ -14,7 +14,7 @@ from easy_thumbnails.fields import ThumbnailerImageField
 from annotations.model_utils import AnnotationArea
 from lib.utils import rand_string
 from sources.models import Source
-from .managers import ImageQuerySet, PointQuerySet
+from .managers import ImageQuerySet, PointManager, PointQuerySet
 from .model_utils import PointGen
 
 
@@ -360,7 +360,7 @@ class Metadata(models.Model):
 
 
 class Point(models.Model):
-    objects = PointQuerySet.as_manager()
+    objects = PointManager.from_queryset(PointQuerySet)()
 
     row = models.IntegerField()
     column = models.IntegerField()

--- a/project/images/tests/test_image_detail_actions.py
+++ b/project/images/tests/test_image_detail_actions.py
@@ -269,6 +269,43 @@ class DeleteAnnotationsTest(ImageDetailActionBaseTest):
             img.annoinfo.last_annotation,
             msg="Should not have a last annotation")
 
+    def test_other_images_unaffected(self):
+        """
+        Like test_success(), but checking that another image wasn't affected.
+        """
+        image1 = self.upload_image(self.user, self.source)
+        image2 = self.upload_image(self.user, self.source)
+
+        for image in [image1, image2]:
+            self.add_annotations(self.user, image, {1: 'A', 2: 'B'})
+            image.annoinfo.refresh_from_db()
+            self.assertEqual(
+                image.annotation_set.count(), 2, msg="Should have annotations")
+            self.assertEqual(
+                image.annoinfo.status, 'confirmed',
+                msg="Should be confirmed")
+
+        response = self.post_to_action_view(self.user, image1)
+        self.assertContains(
+            response, "Successfully removed all annotations from this image.",
+            msg_prefix="Page should show the success message")
+
+        image1.annoinfo.refresh_from_db()
+        self.assertEqual(
+            image1.annotation_set.count(), 0,
+            msg="Annotations should be deleted")
+        self.assertEqual(
+            image1.annoinfo.status, 'unclassified',
+            msg="Should be unclassified")
+
+        image2.annoinfo.refresh_from_db()
+        self.assertEqual(
+            image2.annotation_set.count(), 2,
+            msg="Annotations should not be deleted")
+        self.assertEqual(
+            image2.annoinfo.status, 'confirmed',
+            msg="Should be confirmed")
+
     def test_show_button_if_all_points_have_confirmed_annotations(self):
         self.add_annotations(self.user, self.img, {1: 'A', 2: 'B'})
 
@@ -351,6 +388,46 @@ class RegeneratePointsTest(ImageDetailActionBaseTest):
         self.assertIsNone(
             img.annoinfo.last_annotation,
             msg="Should not have a last annotation")
+
+    @staticmethod
+    def point_pks(image):
+        return list(image.point_set.values_list('pk', flat=True))
+
+    def test_other_images_unaffected(self):
+        """
+        Like test_success(), but checking that another image wasn't affected.
+        """
+        image1 = self.upload_image(self.user, self.source)
+        image2 = self.upload_image(self.user, self.source)
+
+        image1_old_point_pks = self.point_pks(image1)
+        self.assertGreater(
+            len(image1_old_point_pks), 0, msg="Should have points")
+
+        image2_old_point_pks = self.point_pks(image2)
+        self.assertGreater(
+            len(image2_old_point_pks), 0, msg="Should have points")
+
+        response = self.post_to_action_view(self.user, image1)
+        self.assertContains(
+            response, "Successfully regenerated point locations.",
+            msg_prefix="Page should show the success message")
+
+        image1_new_point_pks = self.point_pks(image1)
+        self.assertGreater(
+            len(image1_new_point_pks), 0, msg="Should still have points")
+        self.assertTrue(
+            [new_pk not in image1_old_point_pks
+             for new_pk in image1_new_point_pks],
+            msg="New points should have different IDs from the old ones")
+
+        image2_new_point_pks = self.point_pks(image2)
+        self.assertGreater(
+            len(image2_new_point_pks), 0, msg="Should still have points")
+        self.assertTrue(
+            [new_pk in image2_old_point_pks
+             for new_pk in image2_new_point_pks],
+            msg="New points should have same IDs as the old ones")
 
     def test_deny_if_all_points_have_confirmed_annotations(self):
         self.add_annotations(self.user, self.img, {1: 'A', 2: 'B'})

--- a/project/images/tests/test_models.py
+++ b/project/images/tests/test_models.py
@@ -175,7 +175,7 @@ class MetadataUniqueNamesInSourceTest(CnStandardTest):
                 name='1.PNG')
 
 
-class PointGenTest(CnStandardTest):
+class PointGenUtilTest(CnStandardTest):
 
     def test_point_count_simple_random(self):
         self.assertEqual(
@@ -202,6 +202,69 @@ class PointGenTest(CnStandardTest):
             PointGen(type='imported', points=40).total_points,
             40,
         )
+
+
+class PointCreateTest(CnStandardTest):
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.user = cls.create_user()
+        cls.source = cls.create_source(cls.user)
+        cls.image = cls.upload_image(cls.user, cls.source)
+
+    def test_image_fks_present(self):
+        Point.objects.delete_for_image(self.image)
+        self.assertEqual(self.image.point_set.count(), 0, msg="Sanity check")
+
+        points = [
+            Point(
+                point_number=num, row=num, column=num,
+                image=self.image,
+            )
+            for num in [1,2,3]
+        ]
+        Point.objects.bulk_create_for_image(points, self.image)
+
+        self.assertEqual(self.image.point_set.count(), 3)
+
+    def test_image_fks_present_but_mismatched(self):
+        Point.objects.delete_for_image(self.image)
+        self.assertEqual(self.image.point_set.count(), 0, msg="Sanity check")
+
+        image2 = self.upload_image(self.user, self.source)
+
+        points = [
+            Point(
+                point_number=num, row=num, column=num,
+                image=image2,
+            )
+            for num in [1,2,3]
+        ]
+        with self.assertRaises(ValueError) as cm:
+            Point.objects.bulk_create_for_image(points, self.image)
+
+        self.assertEqual(
+            str(cm.exception),
+            f"Args have clashing Images:"
+            f" ID {image2.pk} vs. ID {self.image.pk}")
+
+        self.assertEqual(self.image.point_set.count(), 0)
+
+    def test_image_fks_absent(self):
+        Point.objects.delete_for_image(self.image)
+        self.assertEqual(self.image.point_set.count(), 0, msg="Sanity check")
+
+        points = [
+            Point(
+                point_number=num, row=num, column=num,
+            )
+            for num in [1,2,3]
+        ]
+        Point.objects.bulk_create_for_image(points, self.image)
+
+        self.assertEqual(self.image.point_set.count(), 3)
 
 
 class PointValidationTest(CnStandardTest):

--- a/project/images/utils.py
+++ b/project/images/utils.py
@@ -443,15 +443,13 @@ def delete_image(img: Image):
     img.delete()
 
 
-def calculate_points(annotation_area, point_gen_spec):
+def calculate_points(
+    annotation_area: AnnotationArea, point_gen_spec: PointGen,
+) -> list[Point]:
     """
     Calculate points for an image. This doesn't actually
-    insert anything in the database; it just generates the
-    row, column for each point number.
-
-    Returns the points as a list of dicts; each dict
-    represents a point, and has keys "row", "column",
-    and "point_number".
+    insert anything in the database; it just returns Points that are ready to
+    be saved other than missing an image-FK value.
     """
 
     points = []
@@ -463,7 +461,6 @@ def calculate_points(annotation_area, point_gen_spec):
 
     annoarea_height = annoarea_max_row - annoarea_min_row + 1
     annoarea_width = annoarea_max_col - annoarea_min_col + 1
-
 
     if point_gen_spec.type == PointGen.Types.SIMPLE.value:
 
@@ -502,7 +499,7 @@ def calculate_points(annotation_area, point_gen_spec):
             for c in range(cell_columns_for_numbering):
                 for p in cell[r][c]:
 
-                    points.append(dict(
+                    points.append(Point(
                         row=p['row'], column=p['column'],
                         point_number=point_num,
                     ))
@@ -532,7 +529,7 @@ def calculate_points(annotation_area, point_gen_spec):
                     row = random.randint(row_min, row_max)
                     column = random.randint(col_min, col_max)
 
-                    points.append(dict(
+                    points.append(Point(
                         row=row, column=column, point_number=point_num,
                     ))
                     point_num += 1
@@ -557,7 +554,7 @@ def calculate_points(annotation_area, point_gen_spec):
                     // point_gen_spec.cell_columns) + annoarea_min_col - 1
                 col_mid = (col_min+col_max) // 2
 
-                points.append(dict(
+                points.append(Point(
                     row=row_mid, column=col_mid, point_number=point_num,
                 ))
                 point_num += 1
@@ -591,16 +588,13 @@ def generate_points(img, usesourcemethod=True):
         point_gen_method = img.source.default_point_generation_method
     else:
         point_gen_method = img.point_generation_method
-    
     new_points = calculate_points(
         annotation_area=anno_area,
         point_gen_spec=PointGen.from_db_value(point_gen_method),
     )
 
-    # Delete old points for this image, if any.
-    old_points = Point.objects.filter(image=img)
-    for old_point in old_points:
-        old_point.delete()
+    # Delete the old points for this image.
+    Point.objects.delete_for_image(img)
 
     # Any CPC (Coral Point Count file) we had saved previously no longer has
     # the correct point positions, so we'll just discard the CPC.
@@ -609,12 +603,7 @@ def generate_points(img, usesourcemethod=True):
     img.save()
 
     # Save the newly calculated points.
-    for new_point in new_points:
-        Point(row=new_point['row'],
-              column=new_point['column'],
-              point_number=new_point['point_number'],
-              image=img,
-        ).save()
+    Point.objects.bulk_create_for_image(new_points, img)
 
 
 def get_carousel_images():

--- a/project/images/views.py
+++ b/project/images/views.py
@@ -154,7 +154,7 @@ def image_delete_annotations(request, image_id):
     """
     image = get_object_or_404(Image, id=image_id)
 
-    Annotation.objects.filter(image=image).delete()
+    Annotation.objects.delete_for_image(image)
 
     messages.success(
         request, 'Successfully removed all annotations from this image.')

--- a/project/labels/tests/test_label_main.py
+++ b/project/labels/tests/test_label_main.py
@@ -548,8 +548,10 @@ class LabelMainPatchesTest(BaseLabelMainTest):
         self.update_cache_and_get_result()
 
         # Delete 2 of the 5 annotations.
-        self.image.annotation_set \
-            .filter(point__point_number__in=[2, 4]).delete()
+        for annotation in self.image.annotation_set.filter(
+            point__point_number__in=[2, 4]
+        ):
+            annotation.delete()
 
         remaining_annotations = set(
             self.image.annotation_set.select_related('point'))

--- a/project/lib/utils.py
+++ b/project/lib/utils.py
@@ -9,8 +9,10 @@ import string
 from typing import Any, Callable
 import urllib.parse
 
+from django.conf import settings
 from django.core.cache import cache
 from django.core.paginator import Page, Paginator, EmptyPage, InvalidPage
+from django.db.models import QuerySet
 from django.template.defaultfilters import date as date_template_filter
 from django.utils import timezone
 
@@ -278,3 +280,33 @@ def rand_string(num_of_chars):
     return ''.join(
         random.choice(string.ascii_lowercase + string.digits)
         for _ in range(num_of_chars))
+
+
+def delete_queryset_in_chunks(queryset: QuerySet):
+    """
+    Calling delete() on a QuerySet may induce Django to fetch all instances to
+    be deleted, for example if there are SET_NULL FKs pointing to the
+    instances being deleted.
+    This could run us out of memory in some cases, like when deleting close to
+    millions of Annotations. This method allows deleting in chunks so that's
+    not a concern.
+    Pattern is from https://stackoverflow.com/questions/60736901/
+    And similar here https://forum.djangoproject.com/t/incremental-bulk-deletion/40833/2
+    We also use only() to reduce what's fetched.
+    """
+    queryset = queryset.only('pk')
+
+    while True:
+        chunk_pks = queryset[:settings.QUERYSET_CHUNK_SIZE].values('pk')
+        if not chunk_pks:
+            break
+
+        chunk_queryset = queryset.model.objects.filter(
+            pk__in=chunk_pks).only('pk')
+
+        # On our main use case thus far, deleting Annotations, we've defined
+        # AnnotationQuerySet.delete() to simply raise an error, so that it's
+        # not naively used (which leads to bookkeeping fields not being
+        # updated + potentially awful performance).
+        # So here we explicitly call the generic QuerySet.delete() instead.
+        QuerySet.delete(chunk_queryset)

--- a/project/vision_backend/task_helpers.py
+++ b/project/vision_backend/task_helpers.py
@@ -129,7 +129,7 @@ def add_annotations(image_id: int,
         #  done on the Annotation History page at some point.
 
     if create_all:
-        Annotation.objects.bulk_create(create_all_list)
+        Annotation.objects.bulk_create_for_image(create_all_list, img)
 
     event = ClassifyImageEvent(
         source_id=img.source_id,

--- a/project/vision_backend/tasks.py
+++ b/project/vision_backend/tasks.py
@@ -714,8 +714,8 @@ def reset_classifiers_for_source(source_id):
     # We do this before deleting Classifiers, since Annotations have FKs to
     # Classifiers, but not vice versa. So this order should reduce a bit of
     # work, and also makes more sense from a data consistency standpoint.
-    Annotation.objects.filter(
-        source_id=source_id).unconfirmed().delete_in_chunks()
+    source = Source.objects.get(pk=source_id)
+    Annotation.objects.delete_unconfirmed_for_source(source)
 
     # There are SET_NULL FKs to Classifiers, so this fetches all classifiers to
     # implement setting null. But that's okay since there aren't many

--- a/project/vision_backend/tests/tasks/test_classify.py
+++ b/project/vision_backend/tests/tasks/test_classify.py
@@ -330,7 +330,7 @@ class SourceCheckImageCasesTest(BaseTaskTest):
             self.classifier_2,
             fill_classifier_field=True,
         )
-        self.img1.annotation_set.delete()
+        Annotation.objects.delete_for_image(self.img1)
         # Even though the field says the classifier's already visited
         # img1, the annotations being deleted indicates it needs a
         # revisit.

--- a/project/vision_backend/tests/tasks/test_misc.py
+++ b/project/vision_backend/tests/tasks/test_misc.py
@@ -2,10 +2,10 @@ import datetime
 import json
 from unittest import mock
 
+from django.db.models import QuerySet
 from django.test.utils import override_settings
 from django.urls import reverse
 
-from annotations.managers import AnnotationQuerySet
 from annotations.models import Annotation
 from jobs.models import Job
 from jobs.tasks import run_scheduled_jobs, run_scheduled_jobs_until_empty
@@ -105,25 +105,27 @@ class ResetClassifiersForSourceTest(BaseTaskTest):
 
         self.upload_data_and_train_classifier()
 
-        for _ in range(5):
+        for _ in range(9):
             self.upload_image_and_machine_classify()
         self.assertEqual(
-            self.source.annotation_set.unconfirmed().count(), 25,
-            "Should have 5x5 = 25 unconfirmed annotations")
+            self.source.annotation_set.unconfirmed().count(), 45,
+            "Should have 9x5 = 45 unconfirmed annotations")
 
         # Finish the scheduled source check.
         run_scheduled_jobs()
 
         # Reset classifiers, while tracking how many chunks are used when
         # deleting the unconfirmed annotations.
-        annotation_delete = spy_decorator(AnnotationQuerySet.delete)
-        with mock.patch.object(AnnotationQuerySet, 'delete', annotation_delete):
+        queryset_delete = spy_decorator(QuerySet.delete)
+        with mock.patch.object(QuerySet, 'delete', queryset_delete):
             do_job(
                 'reset_classifiers_for_source', self.source.pk,
                 source_id=self.source.pk)
         self.assertEqual(
-            annotation_delete.mock_obj.call_count, 3,
-            msg="Should require 3 chunks of 10 to delete 25 annotations"
+            queryset_delete.mock_obj.call_count, 5+2,
+            msg="Should require 5 chunks of 10 to delete 45 annotations,"
+                " and there are 2 other QuerySet.delete() calls for Scores"
+                " and Classifiers, for 5+2 = 7 calls total"
         )
 
         self.assertEqual(


### PR DESCRIPTION
I noticed that batch deletion of annotations was sometimes taking hours, for sets of only around 1000 images. I also noticed one of the long-running queries associated with such a deletion:

> SELECT DISTINCT "images_image"."id", "images_image"."original_file", <...>, "images_image"."unprocessable_reason" FROM "images_image" INNER JOIN "annotations_annotation" ON ("images_image"."id" = "annotations_annotation"."image_id") WHERE "annotations_annotation"."id" IN (SELECT W0."id" FROM "annotations_annotation" W0 WHERE W0."id" IN (SELECT V0."id" FROM "annotations_annotation" V0 WHERE V0."image_id" IN (SELECT U0."id" FROM "images_image" U0 WHERE U0."source_id" = <ID redacted>) LIMIT 100000))

Triple-nested subqueries in this query. What was it even asking for? In this case, essentially "all images in this source".

The part complicating the query was in `AnnotationQuerySet.delete()`. We would get a QuerySet of Annotations, then call `delete()` to delete them in bulk. And this happened in the delete method, with `self` being the QuerySet:

```python
# Get all the images corresponding to these annotations.
images = Image.objects.filter(annotation__in=self).distinct()
# Evaluate the queryset before deleting the annotations.
images = list(images)
# Delete the annotations.
return_values = super().delete()

# The images' annotation progress info may need updating.
for image in images:
    image.annoinfo.update_annotation_progress_fields()
```

So, it needs the Images that correspond to the Annotations in the QuerySet, so that those images' annotation progress fields can be updated. It queries for those Images in a completely general way, and that way, it'll be able to do the query regardless of how complex the Annotation QuerySet is. That's nice and laudable, but unfortunately seems to fall flat performance-wise.

It turns out that we don't call delete() on particularly complex Annotation QuerySets. There are just three kinds of QuerySets we call this on:

- All Annotations of a specific Image
- All Annotations of a set of specific Images
- All unconfirmed Annotations of a Source

So I replaced the `delete()` interface with three different methods: `delete_for_image()`, `delete_for_image_set()`, and `delete_unconfirmed_for_source`. Each has its own logic for getting the images that need their annotation progress fields to be updated. In the first two cases, it's obvious. In the third case, getting all Images with annotation info status `UNCONFIRMED` should do it.

Now, `AnnotationQuerySet.delete()` is the obvious way to bulk-delete Annotations if you're a Django programmer who doesn't know CoralNet's nuances. So I thought there was a chance that I'd later forget what I did here, and attempt to call `delete()` directly, which no longer has any logic for updating annotation progress fields. Thus, statuses could get out of sync, leading to snowballing errors. To reduce this risk, I've made `AnnotationQuerySet.delete()` simply raise a TypeError, rendering it unusable.

Batch deletion of annotations wasn't the only thing updating annotation progress fields in this manner. Altogether, the following all seemed capable of generating triply-nested subqueries:

- Batch deletion of annotations
- Batch (bulk) creation of annotations
- Batch deletion of points
- Batch (bulk) creation of points

So I updated all of these operations in a similar fashion. The other three operations here each had only one case to handle: delete/create annotations/points for a single image.

While I was at it, I checked on the places where we create/delete annotations or points one by one. Creating annotations in the annotation tool still relies on django-reversion save() handling, so that still has to be one by one. However, point (re)generation doesn't have to create/delete points one by one, so I updated that to use bulk creation/deletion.

Overall, functions such as the following could see appreciable speedups from this work:

- Batch delete annotations
- Reset classifiers for source (the annotation deletion part)
- Annotation upload by CSV or CPC (all four types of ops happen here)
- Machine classification of images (the annotation creation part)
- Image upload (the point generation part)